### PR TITLE
Chapter 5: Representing Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,6 @@
 A [Lox](http://craftinginterpreters.com/the-lox-language.html) Interpreter in Rust based on the
 [Crafting Interpreters](http://craftinginterpreters.com) book.
 
-Each commit corresponds to one chapter in the book.
+Each commit corresponds to one chapter in the book:
+
+* [Chapter 4](https://github.com/jeschkies/lox-rs/commit/9fef15e73fdf57a3e428bb074059c7e144e257f7)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod error;
 mod scanner;
+mod syntax;
 mod token;
 
 use std::io::{self, BufRead};
@@ -7,8 +8,26 @@ use std::process::exit;
 use std::{env, fs};
 
 use scanner::Scanner;
+use syntax::{AstPrinter, Expr};
+use token::{Token, TokenType};
 
 fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
+    let expression = Expr::Binary {
+        left: Box::new(Expr::Unary {
+            operator: Token::new(TokenType::Minus,"-", 1),
+            right: Box::new(Expr::Literal {
+                value: "123".to_string(),
+            }),
+        }),
+        operator: Token::new(TokenType::Star, "*", 1),
+        right: Box::new(Expr::Grouping {
+            expression: Box::new(Expr::Literal {
+                value: "45.67".to_string(),
+            }),
+        }),
+    };
+    let printer = AstPrinter;
+    println!("{}", printer.print(expression));
     let args: Vec<String> = env::args().collect();
     match args.as_slice() {
         [_, file] => run_file(file)?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,26 +8,8 @@ use std::process::exit;
 use std::{env, fs};
 
 use scanner::Scanner;
-use syntax::{AstPrinter, Expr};
-use token::{Token, TokenType};
 
 fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
-    let expression = Expr::Binary {
-        left: Box::new(Expr::Unary {
-            operator: Token::new(TokenType::Minus,"-", 1),
-            right: Box::new(Expr::Literal {
-                value: "123".to_string(),
-            }),
-        }),
-        operator: Token::new(TokenType::Star, "*", 1),
-        right: Box::new(Expr::Grouping {
-            expression: Box::new(Expr::Literal {
-                value: "45.67".to_string(),
-            }),
-        }),
-    };
-    let printer = AstPrinter;
-    println!("{}", printer.print(expression));
     let args: Vec<String> = env::args().collect();
     match args.as_slice() {
         [_, file] => run_file(file)?,

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,8 +1,75 @@
 use crate::token::Token;
 
 pub enum Expr {
-    Binary { left: Expr, operator: Token, right: Expr },
-    Grouping {expression: Expr },
-    Literal { value: String }, // Object in chapter 5
-    Unaary { operator: Token, right: Expr },
+    Binary {
+        left: Box<Expr>,
+        operator: Token,
+        right: Box<Expr>,
+    },
+    Grouping {
+        expression: Box<Expr>,
+    },
+    Literal {
+        value: String,
+    }, // Object in chapter 5
+    Unary {
+        operator: Token,
+        right: Box<Expr>,
+    },
+}
+
+pub trait Visitor<R> {
+    fn visit_binary_expr(&self, left: &Expr, operator: &Token, right: &Expr) -> R;
+    fn visit_grouping_expr(&self, expression: &Expr) -> R;
+    fn visit_literal_expr(&self, value: String) -> R;
+    fn visit_unary_expr(&self, operator: &Token, right: &Expr) -> R;
+}
+
+impl Expr {
+    pub fn accept<R>(&self, visitor: &Visitor<R>) -> R {
+        match self {
+            Expr::Binary {left, operator, right} => visitor.visit_binary_expr(left, operator, right),
+            Expr::Grouping { expression } => visitor.visit_grouping_expr(expression),
+            Expr::Literal { value } => visitor.visit_literal_expr(value.to_string()),
+            Expr::Unary {operator, right } => visitor.visit_unary_expr(operator, right),
+        }
+    }
+}
+
+pub struct AstPrinter;
+
+impl AstPrinter {
+    pub fn print(&self, expr: Expr) -> String {
+        expr.accept(self)
+    }
+
+    fn parenthesize(&self, name: String, exprs: Vec<&Expr>) -> String {
+        let mut r = String::new();
+        r.push_str("(");
+        r.push_str(&name);
+        for e in &exprs {
+            r.push_str(" ");
+            r.push_str(&e.accept(self));
+        }
+        r.push_str(")");
+        r
+    }
+}
+
+impl Visitor<String> for AstPrinter {
+    fn visit_binary_expr(&self, left: &Expr, operator: &Token, right: &Expr) -> String {
+        self.parenthesize(operator.lexeme.clone(), vec![left, right])
+    }
+
+    fn visit_grouping_expr(&self, expr: &Expr) -> String {
+        self.parenthesize("group".to_string(), vec![expr])
+    }
+
+    fn visit_literal_expr(&self, value: String) -> String {
+        value // check for null
+    }
+
+    fn visit_unary_expr(&self, operator: &Token, right: &Expr) -> String {
+        self.parenthesize(operator.lexeme.clone(), vec![right])
+    }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -73,3 +73,31 @@ impl Visitor<String> for AstPrinter {
         self.parenthesize(operator.lexeme.clone(), vec![right])
     }
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::token::{Token, TokenType};
+
+    #[test]
+    fn test_printer() {
+        let expression = Expr::Binary {
+            left: Box::new(Expr::Unary {
+                operator: Token::new(TokenType::Minus,"-", 1),
+                right: Box::new(Expr::Literal {
+                    value: "123".to_string(),
+                }),
+            }),
+            operator: Token::new(TokenType::Star, "*", 1),
+            right: Box::new(Expr::Grouping {
+                expression: Box::new(Expr::Literal {
+                    value: "45.67".to_string(),
+                }),
+            }),
+        };
+        let printer = AstPrinter;
+
+        assert_eq!(printer.print(expression), "(* (- 123) (group 45.67))");
+    }
+}

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,0 +1,8 @@
+use crate::token::Token;
+
+pub enum Expr {
+    Binary { left: Expr, operator: Token, right: Expr },
+    Grouping {expression: Expr },
+    Literal { value: String }, // Object in chapter 5
+    Unaary { operator: Token, right: Expr },
+}

--- a/src/token.rs
+++ b/src/token.rs
@@ -58,7 +58,7 @@ include!(concat!(env!("OUT_DIR"), "/keywords.rs"));
 
 pub struct Token {
     tpe: TokenType,
-    lexeme: String,
+    pub lexeme: String,
     line: i32,
 }
 


### PR DESCRIPTION
This implements the [code representation in an AST](http://craftinginterpreters.com/representing-code.html).

The visitor pattern is slightly different from the original Java. I had to box the enum values.
This should be suffice for now since I am not aiming at performance yet.