### PR TITLE
Chapter 6: Parsing Expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ A [Lox](http://craftinginterpreters.com/the-lox-language.html) Interpreter in Ru
 Each commit corresponds to one chapter in the book:
 
 * [Chapter 4](https://github.com/jeschkies/lox-rs/commit/9fef15e73fdf57a3e428bb074059c7e144e257f7)
+* [Chapter 5](https://github.com/jeschkies/lox-rs/commit/0156a95b4bf448dbff9cb4341a2339b741a163ca)

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,7 @@
+use std::fmt;
+
+use crate::token::{Token, TokenType};
+
 pub fn error(line: i32, message: &str) {
     report(line, "", message);
 }
@@ -5,4 +9,25 @@ pub fn error(line: i32, message: &str) {
 pub fn report(line: i32, where_: &str, message: &str) {
     eprintln!("[line {}] Error{}: {}", line, where_, message);
     // had_error = true; TODO: Use custom Error type
+}
+
+pub fn parser_error(token: &Token, message: &str) {
+    if token.tpe == TokenType::EOF {
+        report(token.line, " at end", message);
+    } else {
+        report(token.line, &format!(" at '{}'", token.lexeme), message);
+    }
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Parser,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Parser => write!(f, "ParserError"),
+        }
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,13 +21,13 @@ pub fn parser_error(token: &Token, message: &str) {
 
 #[derive(Debug)]
 pub enum Error {
-    Parser,
+    Parse,
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Parser => write!(f, "ParserError"),
+            Error::Parse => write!(f, "ParseError"),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,9 @@ use std::io::{self, BufRead};
 use std::process::exit;
 use std::{env, fs};
 
+use parser::Parser;
 use scanner::Scanner;
+use syntax::AstPrinter;
 
 fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     let args: Vec<String> = env::args().collect();
@@ -41,9 +43,9 @@ fn run(source: String) -> io::Result<()> {
     let mut scanner = Scanner::new(source);
     let tokens = scanner.scan_tokens();
 
-    let mut parser = parser::Parser::new(tokens);
+    let mut parser = Parser::new(tokens);
     if let Some(expression) = parser.parse() {
-        let printer = syntax::AstPrinter;
+        let printer = AstPrinter;
         println!("{}", printer.print(expression));
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,8 +41,10 @@ fn run(source: String) -> io::Result<()> {
     let mut scanner = Scanner::new(source);
     let tokens = scanner.scan_tokens();
 
-    for token in tokens {
-        println!("{}", token);
+    let mut parser = parser::Parser::new(tokens);
+    if let Some(expression) = parser.parse() {
+        let printer = syntax::AstPrinter;
+        println!("{}", printer.print(expression));
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod error;
+mod parser;
 mod scanner;
 mod syntax;
 mod token;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,9 +3,10 @@ use crate::token::{Token, TokenType};
 
 struct Parser {
     tokens: Vec<Token>,
-    current: i64,
+    current: usize,
 }
 
+/// AKA match in Chapter 6.
 macro_rules! matches {
     ( $sel:ident, $( $x:expr ),* ) => {
         {
@@ -32,7 +33,7 @@ impl Parser {
         let mut expr = self.comparison();
 
         while matches!(self, TokenType::BangEqual, TokenType::EqualEqual) {
-            let operator: Token = self.previous();
+            let operator: Token = (*self.previous()).clone();
             let right: Expr = self.comparison();
             expr = Expr::Binary {
                 left: Box::new(expr),
@@ -52,23 +53,94 @@ impl Parser {
         token_type == self.peek().tpe
     }
 
-    fn advance(&self) {
-        unimplemented!()
+    fn advance(&mut self) -> &Token {
+        if self.is_at_end() {
+            self.current += 1;
+        }
+        self.previous()
     }
 
-    fn previous(&self) -> Token {
-        unimplemented!()
+    fn previous(&self) -> &Token {
+        self.tokens
+            .get(self.current - 1)
+            .expect("Previous was empty.")
     }
 
-    fn peek(&self) -> Token {
-        unimplemented!()
+    fn peek(&self) -> &Token {
+        self.tokens
+            .get(self.current)
+            .expect("Peek into end of token stream.")
     }
 
     fn is_at_end(&self) -> bool {
-        unimplemented!()
+        self.peek().tpe == TokenType::EOF
     }
 
-    fn comparison(&self) -> Expr {
+    fn comparison(&mut self) -> Expr {
+        let mut expr = self.addition();
+
+        while matches!(
+            self,
+            TokenType::Greater,
+            TokenType::GreaterEqual,
+            TokenType::Less,
+            TokenType::LessEqual
+        ) {
+            let operator = (*self.previous()).clone();
+            let right = self.addition();
+            expr = Expr::Binary {
+                left: Box::new(expr),
+                operator,
+                right: Box::new(right),
+            }
+        }
+
+        expr
+    }
+
+    fn addition(&mut self) -> Expr {
+        let mut expr = self.multiplication();
+
+        while matches!(self, TokenType::Minus, TokenType::Plus) {
+            let operator = (*self.previous()).clone();
+            let right = self.multiplication();
+            expr = Expr::Binary {
+                left: Box::new(expr),
+                operator,
+                right: Box::new(right),
+            }
+        }
+
+        expr
+    }
+
+    fn multiplication(&mut self) -> Expr {
+        let mut expr = self.unary();
+
+        while matches!(self, TokenType::Slash, TokenType::Star) {
+            let operator = (*self.previous()).clone();
+            let right = self.unary();
+            expr = Expr::Binary {
+                left: Box::new(expr),
+                operator,
+                right: Box::new(right),
+            }
+        }
+
+        expr
+    }
+
+    fn unary(&mut self) -> Expr {
+        if matches!(self, TokenType::Bang, TokenType::Minus) {
+            let operator = (*self.previous()).clone();
+            let right = self.unary();
+            Expr::Unary {operator, right: Box::new(right)}
+        } else {
+            self.primary()
+        }
+    }
+
+    fn primary(&mut self) -> Expr {
         unimplemented!()
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,8 +2,8 @@ use crate::error::{parser_error, Error};
 use crate::syntax::{Expr, LiteralValue};
 use crate::token::{Token, TokenType};
 
-struct Parser {
-    tokens: Vec<Token>,
+pub struct Parser<'t> {
+    tokens: &'t Vec<Token>,
     current: usize,
 }
 
@@ -21,13 +21,13 @@ macro_rules! matches {
     };
 }
 
-impl Parser {
-    fn new(tokens: Vec<Token>) -> Self {
+impl<'t> Parser<'t> {
+    pub fn new(tokens: &'t Vec<Token>) -> Self {
         Parser { tokens, current: 0 }
     }
 
-    fn parse(&mut self) -> Expr {
-        self.expression().expect("TODO: Handle parse error.")
+    pub fn parse(&mut self) -> Option<Expr> {
+        self.expression().ok()
     }
 
     fn expression(&mut self) -> Result<Expr, Error> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -9,7 +9,7 @@ struct Parser {
 macro_rules! matches {
     ( $sel:ident, $( $x:expr ),* ) => {
         {
-            if $( $sel.check($x) )&&* {
+            if $( $sel.check($x) )||* {
                 $sel.advance();
                 true
             } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -67,7 +67,7 @@ impl<'t> Parser<'t> {
     }
 
     fn advance(&mut self) -> &Token {
-        if self.is_at_end() {
+        if !self.is_at_end() {
             self.current += 1;
         }
         self.previous()
@@ -214,5 +214,24 @@ impl<'t> Parser<'t> {
         self.advance();
 
         Ok(expr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scanner::Scanner;
+    use crate::syntax::AstPrinter;
+
+    #[test]
+    fn test_parser() {
+        let mut scanner = Scanner::new("-123 * 45.67".to_string());
+        let tokens = scanner.scan_tokens();
+
+        let mut parser = Parser::new(tokens);
+        let expression = parser.parse().expect("Could not parse sample code.");
+        let printer = AstPrinter;
+
+        assert_eq!(printer.print(expression), "(* (- 123) 45.67)");
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,16 +26,20 @@ impl Parser {
         Parser { tokens, current: 0 }
     }
 
-    fn expression(&mut self) -> Expr {
+    fn parse(&mut self) -> Expr {
+        self.expression().expect("TODO: Handle parse error.")
+    }
+
+    fn expression(&mut self) -> Result<Expr, Error> {
         self.equality()
     }
 
-    fn equality(&mut self) -> Expr {
-        let mut expr = self.comparison();
+    fn equality(&mut self) -> Result<Expr, Error> {
+        let mut expr = self.comparison()?;
 
         while matches!(self, TokenType::BangEqual, TokenType::EqualEqual) {
             let operator: Token = (*self.previous()).clone();
-            let right: Expr = self.comparison();
+            let right: Expr = self.comparison()?;
             expr = Expr::Binary {
                 left: Box::new(expr),
                 operator,
@@ -43,7 +47,7 @@ impl Parser {
             };
         }
 
-        expr
+        Ok(expr)
     }
 
     fn check(&self, token_type: TokenType) -> bool {
@@ -112,8 +116,8 @@ impl Parser {
         self.peek().tpe == TokenType::EOF
     }
 
-    fn comparison(&mut self) -> Expr {
-        let mut expr = self.addition();
+    fn comparison(&mut self) -> Result<Expr, Error> {
+        let mut expr = self.addition()?;
 
         while matches!(
             self,
@@ -123,7 +127,7 @@ impl Parser {
             TokenType::LessEqual
         ) {
             let operator: Token = self.previous().clone();
-            let right = self.addition();
+            let right = self.addition()?;
             expr = Expr::Binary {
                 left: Box::new(expr),
                 operator,
@@ -131,15 +135,15 @@ impl Parser {
             }
         }
 
-        expr
+        Ok(expr)
     }
 
-    fn addition(&mut self) -> Expr {
-        let mut expr = self.multiplication();
+    fn addition(&mut self) -> Result<Expr, Error> {
+        let mut expr = self.multiplication()?;
 
         while matches!(self, TokenType::Minus, TokenType::Plus) {
             let operator: Token = self.previous().clone();
-            let right = self.multiplication();
+            let right = self.multiplication()?;
             expr = Expr::Binary {
                 left: Box::new(expr),
                 operator,
@@ -147,15 +151,15 @@ impl Parser {
             }
         }
 
-        expr
+        Ok(expr)
     }
 
-    fn multiplication(&mut self) -> Expr {
-        let mut expr = self.unary();
+    fn multiplication(&mut self) -> Result<Expr, Error> {
+        let mut expr = self.unary()?;
 
         while matches!(self, TokenType::Slash, TokenType::Star) {
             let operator: Token = self.previous().clone();
-            let right = self.unary();
+            let right = self.unary()?;
             expr = Expr::Binary {
                 left: Box::new(expr),
                 operator,
@@ -163,55 +167,52 @@ impl Parser {
             }
         }
 
-        expr
+        Ok(expr)
     }
 
-    fn unary(&mut self) -> Expr {
+    fn unary(&mut self) -> Result<Expr, Error> {
         if matches!(self, TokenType::Bang, TokenType::Minus) {
             let operator: Token = self.previous().clone();
-            let right = self.unary();
-            Expr::Unary {
+            let right = self.unary()?;
+            Ok(Expr::Unary {
                 operator,
                 right: Box::new(right),
-            }
+            })
         } else {
             self.primary()
         }
     }
 
-    fn primary(&mut self) -> Expr {
+    fn primary(&mut self) -> Result<Expr, Error> {
         // We don't use matches!() here since we want to extract the literals.
-        if !self.is_at_end() {
-            let expr = match &self.peek().tpe {
-                TokenType::False => Expr::Literal {
-                    value: LiteralValue::Boolean(false),
-                },
-                TokenType::True => Expr::Literal {
-                    value: LiteralValue::Boolean(true),
-                },
-                TokenType::Nil => Expr::Literal {
-                    value: LiteralValue::Null,
-                },
-                TokenType::String { literal } => Expr::Literal {
-                    value: LiteralValue::String(literal.clone()),
-                },
-                TokenType::Number { literal } => Expr::Literal {
-                    value: LiteralValue::Number(literal.clone()),
-                },
-                TokenType::LeftParen => {
-                    let expr = self.expression();
-                    self.consume(TokenType::RightParen, "Expected ')' after expression.")
-                        .expect("Unhandled error"); // TODO: handle result
-                    Expr::Grouping {
-                        expression: Box::new(expr),
-                    }
+        let expr = match &self.peek().tpe {
+            TokenType::False => Expr::Literal {
+                value: LiteralValue::Boolean(false),
+            },
+            TokenType::True => Expr::Literal {
+                value: LiteralValue::Boolean(true),
+            },
+            TokenType::Nil => Expr::Literal {
+                value: LiteralValue::Null,
+            },
+            TokenType::String { literal } => Expr::Literal {
+                value: LiteralValue::String(literal.clone()),
+            },
+            TokenType::Number { literal } => Expr::Literal {
+                value: LiteralValue::Number(literal.clone()),
+            },
+            TokenType::LeftParen => {
+                let expr = self.expression()?;
+                self.consume(TokenType::RightParen, "Expected ')' after expression.")?;
+                Expr::Grouping {
+                    expression: Box::new(expr),
                 }
-                _ => panic!("Unexpected token"),
-            };
-            self.advance();
-            expr
-        } else {
-            panic!("Unexpected end.")
-        }
+            }
+            _ => return Err(self.error(self.peek(), "Expect expression.")),
+        };
+
+        self.advance();
+
+        Ok(expr)
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -77,7 +77,29 @@ impl Parser {
 
     fn error(&self, token: &Token, message: &str) -> Error {
         parser_error(token, message);
-        Error::Parser
+        Error::Parse
+    }
+
+    fn synchronize(&mut self) {
+        self.advance();
+
+        while !self.is_at_end() {
+            if self.previous().tpe == TokenType::Semicolon {
+                return;
+            }
+
+            match self.peek().tpe {
+                TokenType::Class
+                | TokenType::Fun
+                | TokenType::Var
+                | TokenType::For
+                | TokenType::If
+                | TokenType::While
+                | TokenType::Print
+                | TokenType::Return => return,
+                _ => self.advance(),
+            };
+        }
     }
 
     fn peek(&self) -> &Token {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -144,6 +144,7 @@ impl Parser {
     }
 
     fn primary(&mut self) -> Expr {
+        /* We don't use matches!() here since we want to extract the literals. */
         if !self.is_at_end() {
             let expr = match &self.peek().tpe {
                 TokenType::False => Expr::Literal {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,0 +1,52 @@
+use crate::syntax::Expr;
+use crate::token::{Token, TokenType};
+
+struct Parser {
+    tokens: Vec<Token>,
+    current: i64,
+}
+
+macro_rules! matches {
+    ( $sel:ident, $( $x:expr ),* ) => {
+        {
+            if $( $sel.check($x) )&&* {
+                $sel.advance();
+                true
+            } else {
+                false
+            }
+        }
+    };
+}
+
+impl Parser {
+    fn new(tokens: Vec<Token>) -> Self {
+        Parser { tokens, current: 0 }
+    }
+
+    fn expression(&mut self) -> Expr {
+        self.equality()
+    }
+
+    fn equality(&mut self) -> Expr {
+        let mut expr = self.comparison();
+
+        while matches!(self, TokenType::BangEqual, TokenType::EqualEqual) {
+            let operator: Token = self.previous();
+            let right: Expr = self.comparison();
+            expr = Expr::Binary {
+                left: Box::new(expr),
+                operator,
+                right: Box::new(right),
+            };
+        }
+
+        expr
+    }
+
+    fn check(&self, toke_type: TokenType) -> bool {
+        false
+    }
+
+    fn advance(&self) {}
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -44,9 +44,31 @@ impl Parser {
         expr
     }
 
-    fn check(&self, toke_type: TokenType) -> bool {
-        false
+    fn check(&self, token_type: TokenType) -> bool {
+        if self.is_at_end() {
+            return false;
+        }
+
+        token_type == self.peek().tpe
     }
 
-    fn advance(&self) {}
+    fn advance(&self) {
+        unimplemented!()
+    }
+
+    fn previous(&self) -> Token {
+        unimplemented!()
+    }
+
+    fn peek(&self) -> Token {
+        unimplemented!()
+    }
+
+    fn is_at_end(&self) -> bool {
+        unimplemented!()
+    }
+
+    fn comparison(&self) -> Expr {
+        unimplemented!()
+    }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,4 +1,5 @@
 use crate::token::Token;
+use std::fmt;
 
 pub enum Expr {
     Binary {
@@ -10,12 +11,30 @@ pub enum Expr {
         expression: Box<Expr>,
     },
     Literal {
-        value: String,
-    }, // Object in chapter 5
+        value: LiteralValue,
+    },
     Unary {
         operator: Token,
         right: Box<Expr>,
     },
+}
+
+pub enum LiteralValue {
+    Boolean(bool),
+    Null,
+    Number(f64),
+    String(String),
+}
+
+impl fmt::Display for LiteralValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LiteralValue::Boolean(b) => write!(f, "{}", b),
+            LiteralValue::Null => write!(f, "null"),
+            LiteralValue::Number(n) => write!(f, "{}", n),
+            LiteralValue::String(s) => write!(f, "{}", s),
+        }
+    }
 }
 
 pub trait Visitor<R> {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -28,10 +28,14 @@ pub trait Visitor<R> {
 impl Expr {
     pub fn accept<R>(&self, visitor: &Visitor<R>) -> R {
         match self {
-            Expr::Binary {left, operator, right} => visitor.visit_binary_expr(left, operator, right),
+            Expr::Binary {
+                left,
+                operator,
+                right,
+            } => visitor.visit_binary_expr(left, operator, right),
             Expr::Grouping { expression } => visitor.visit_grouping_expr(expression),
             Expr::Literal { value } => visitor.visit_literal_expr(value.to_string()),
-            Expr::Unary {operator, right } => visitor.visit_unary_expr(operator, right),
+            Expr::Unary { operator, right } => visitor.visit_unary_expr(operator, right),
         }
     }
 }
@@ -74,7 +78,6 @@ impl Visitor<String> for AstPrinter {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -84,7 +87,7 @@ mod tests {
     fn test_printer() {
         let expression = Expr::Binary {
             left: Box::new(Expr::Unary {
-                operator: Token::new(TokenType::Minus,"-", 1),
+                operator: Token::new(TokenType::Minus, "-", 1),
                 right: Box::new(Expr::Literal {
                     value: "123".to_string(),
                 }),

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -108,13 +108,13 @@ mod tests {
             left: Box::new(Expr::Unary {
                 operator: Token::new(TokenType::Minus, "-", 1),
                 right: Box::new(Expr::Literal {
-                    value: "123".to_string(),
+                    value: LiteralValue::Number(123f64),
                 }),
             }),
             operator: Token::new(TokenType::Star, "*", 1),
             right: Box::new(Expr::Grouping {
                 expression: Box::new(Expr::Literal {
-                    value: "45.67".to_string(),
+                    value: LiteralValue::Number(45.67f64),
                 }),
             }),
         };

--- a/src/token.rs
+++ b/src/token.rs
@@ -60,7 +60,7 @@ include!(concat!(env!("OUT_DIR"), "/keywords.rs"));
 pub struct Token {
     pub tpe: TokenType,
     pub lexeme: String,
-    line: i32,
+    pub line: i32,
 }
 
 impl Token {

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 extern crate phf;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TokenType {
     // Single-character tokens.
     LeftParen,

--- a/src/token.rs
+++ b/src/token.rs
@@ -56,6 +56,7 @@ pub enum TokenType {
 // Generated via phf_codegen until proc_macro_hygiene is stable.
 include!(concat!(env!("OUT_DIR"), "/keywords.rs"));
 
+#[derive(Debug, Clone, PartialEq)]
 pub struct Token {
     pub tpe: TokenType,
     pub lexeme: String,

--- a/src/token.rs
+++ b/src/token.rs
@@ -57,7 +57,7 @@ pub enum TokenType {
 include!(concat!(env!("OUT_DIR"), "/keywords.rs"));
 
 pub struct Token {
-    tpe: TokenType,
+    pub tpe: TokenType,
     pub lexeme: String,
     line: i32,
 }


### PR DESCRIPTION
This implements the [parsing](http://www.craftinginterpreters.com/parsing-expressions.htmll).

A few differences:
* `matches!` is a macro to allow varargs. It stands in for `match` from the Java version.
* The literals are typed via `LiteralValue`.
* `primary` does not use `matches!` but the Rust pattern matching to extract values.
* We use `Result` instead of exceptions.