### PR TITLE
Chapter 7: Evaluating Expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ Each commit corresponds to one chapter in the book:
 
 * [Chapter 4](https://github.com/jeschkies/lox-rs/commit/9fef15e73fdf57a3e428bb074059c7e144e257f7)
 * [Chapter 5](https://github.com/jeschkies/lox-rs/commit/0156a95b4bf448dbff9cb4341a2339b741a163ca)
+* [Chapter 6](https://github.com/jeschkies/lox-rs/commit/9508c9d887a88540597d314520ae6aa045256e7d)

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,6 @@
+use std::convert;
 use std::fmt;
+use std::io;
 
 use crate::token::{Token, TokenType};
 
@@ -21,13 +23,29 @@ pub fn parser_error(token: &Token, message: &str) {
 
 #[derive(Debug)]
 pub enum Error {
+    Io(io::Error),
     Parse,
+    Runtime { token: Token, message: String },
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Error::Io(underlying) => write!(f, "IoError {}", underlying),
             Error::Parse => write!(f, "ParseError"),
+            Error::Runtime { message, .. } => write!(f, "RuntimeError {}", message),
         }
+    }
+}
+
+impl std::error::Error for Error {
+    fn description(&self) -> &str {
+        "Lox Error"
+    }
+}
+
+impl convert::From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Error::Io(e)
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -26,10 +26,29 @@ impl Interpreter {
 }
 
 impl Visitor<Object> for Interpreter {
-    // TODO: Book defines result type as Object
 
     fn visit_binary_expr(&self, left: &Expr, operator: &Token, right: &Expr) -> Object {
-        unimplemented!()
+        let l = self.evaluate(left);
+        let r = self.evaluate(right);
+
+        match (l, &operator.tpe, r) {
+            (Object::Number(left_number), TokenType::Minus, Object::Number(right_number)) => {
+                Object::Number(left_number - right_number)
+            }
+            (Object::Number(left_number), TokenType::Plus, Object::Number(right_number)) => {
+                Object::Number(left_number + right_number)
+            }
+            (Object::String(left_string), TokenType::Plus, Object::String(right_string)) => {
+                Object::String(left_string.clone() + &right_string)
+            }
+            (Object::Number(left_number), TokenType::Slash, Object::Number(right_number)) => {
+                Object::Number(left_number / right_number)
+            }
+            (Object::Number(left_number), TokenType::Star, Object::Number(right_number)) => {
+                Object::Number(left_number * right_number)
+            }
+            _ => unreachable!(), // TODO: handle other types
+        }
     }
 
     fn visit_grouping_expr(&self, expr: &Expr) -> Object {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -27,13 +27,8 @@ impl Object {
 pub struct Interpreter;
 
 impl Interpreter {
-
-    fn interpret(&self, expression: &Expr) {
-        match self.evaluate(expression) {
-            Ok(value) => println!("{}", self.stringify(value)),
-            Err(_) => unimplemented!(),
-//            Err(e: Error::Runtime) => runtime_error(e),
-        }
+    pub fn interpret(&self, expression: &Expr) -> Result<String, Error> {
+        self.evaluate(expression).map(|value| self.stringify(value))
     }
 
     fn evaluate(&self, expression: &Expr) -> Result<Object, Error> {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,0 +1,36 @@
+use crate::syntax::{Expr, LiteralValue, Visitor};
+use crate::token::Token;
+
+/// A simple representation of an Lox object akin to a Java `Object`.
+enum Object {
+    Boolean(bool),
+    Null,
+    Number(f64),
+    String(String),
+}
+
+pub struct Interpreter;
+
+impl Visitor<Object> for Interpreter { // TODO: Book defines result type as Object
+
+    fn visit_binary_expr(&self, left: &Expr, operator: &Token, right: &Expr) -> Object {
+        unimplemented!()
+    }
+
+    fn visit_grouping_expr(&self, expr: &Expr) -> Object {
+        unimplemented!()
+    }
+
+    fn visit_literal_expr(&self, value: &LiteralValue) -> Object {
+       match value  {
+           LiteralValue::Boolean(b) => Object::Boolean(b.clone()),
+           LiteralValue::Null => Object::Null,
+           LiteralValue::Number(n) => Object::Number(n.clone()),
+           LiteralValue::String(s) => Object::String(s.clone()),
+       }
+    }
+
+    fn visit_unary_expr(&self, operator: &Token, right: &Expr) -> Object {
+        unimplemented!()
+    }
+}

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,5 +1,5 @@
 use crate::syntax::{Expr, LiteralValue, Visitor};
-use crate::token::Token;
+use crate::token::{Token, TokenType};
 
 /// A simple representation of an Lox object akin to a Java `Object`.
 enum Object {
@@ -12,13 +12,21 @@ enum Object {
 pub struct Interpreter;
 
 impl Interpreter {
-
     fn evaluate(&self, expression: &Expr) -> Object {
         expression.accept(self)
     }
+
+    fn is_truthy(&self, object: &Object) -> bool {
+        match object {
+            Object::Null => false,
+            Object::Boolean(b) => b.clone(),
+            _ => true,
+        }
+    }
 }
 
-impl Visitor<Object> for Interpreter { // TODO: Book defines result type as Object
+impl Visitor<Object> for Interpreter {
+    // TODO: Book defines result type as Object
 
     fn visit_binary_expr(&self, left: &Expr, operator: &Token, right: &Expr) -> Object {
         unimplemented!()
@@ -29,15 +37,21 @@ impl Visitor<Object> for Interpreter { // TODO: Book defines result type as Obje
     }
 
     fn visit_literal_expr(&self, value: &LiteralValue) -> Object {
-       match value  {
-           LiteralValue::Boolean(b) => Object::Boolean(b.clone()),
-           LiteralValue::Null => Object::Null,
-           LiteralValue::Number(n) => Object::Number(n.clone()),
-           LiteralValue::String(s) => Object::String(s.clone()),
-       }
+        match value {
+            LiteralValue::Boolean(b) => Object::Boolean(b.clone()),
+            LiteralValue::Null => Object::Null,
+            LiteralValue::Number(n) => Object::Number(n.clone()),
+            LiteralValue::String(s) => Object::String(s.clone()),
+        }
     }
 
     fn visit_unary_expr(&self, operator: &Token, right: &Expr) -> Object {
-        unimplemented!()
+        let right = self.evaluate(right);
+
+        match (&operator.tpe, &right) {
+            (TokenType::Minus, Object::Number(n)) => Object::Number(-n.clone()),
+            (TokenType::Bang, _) => Object::Boolean(!self.is_truthy(&right)), // TODO: is_truthy could simply return an Object.
+            _ => unreachable!(), // TODO: fail if right is not a number.
+        }
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,3 +1,4 @@
+use crate::error::Error;
 use crate::syntax::{Expr, LiteralValue, Visitor};
 use crate::token::{Token, TokenType};
 
@@ -26,7 +27,7 @@ impl Object {
 pub struct Interpreter;
 
 impl Interpreter {
-    fn evaluate(&self, expression: &Expr) -> Object {
+    fn evaluate(&self, expression: &Expr) -> Result<Object, Error> {
         expression.accept(self)
     }
 
@@ -41,72 +42,109 @@ impl Interpreter {
     fn is_equal(&self, left: &Object, right: &Object) -> bool {
         left.equals(right)
     }
+
+    /// Equivalent to checkNumberOperands
+    fn number_operand_error<R>(&self, operator: &Token) -> Result<R, Error> {
+        Err(Error::Runtime {
+            token: operator.clone(),
+            message: "Operand must be a number.".to_string(),
+        })
+    }
 }
 
 impl Visitor<Object> for Interpreter {
-    fn visit_binary_expr(&self, left: &Expr, operator: &Token, right: &Expr) -> Object {
-        let l = self.evaluate(left);
-        let r = self.evaluate(right);
+    fn visit_binary_expr(
+        &self,
+        left: &Expr,
+        operator: &Token,
+        right: &Expr,
+    ) -> Result<Object, Error> {
+        let l = self.evaluate(left)?;
+        let r = self.evaluate(right)?;
 
-        match (l, &operator.tpe, r) {
-            (Object::Number(left_number), TokenType::Greater, Object::Number(right_number)) => {
-                Object::Boolean(left_number > right_number)
-            }
-            (
-                Object::Number(left_number),
-                TokenType::GreaterEqual,
-                Object::Number(right_number),
-            ) => Object::Boolean(left_number >= right_number),
-            (Object::Number(left_number), TokenType::Less, Object::Number(right_number)) => {
-                Object::Boolean(left_number < right_number)
-            }
-            (Object::Number(left_number), TokenType::LessEqual, Object::Number(right_number)) => {
-                Object::Boolean(left_number <= right_number)
-            }
-            (Object::Number(left_number), TokenType::Minus, Object::Number(right_number)) => {
-                Object::Number(left_number - right_number)
-            }
-            (Object::Number(left_number), TokenType::Plus, Object::Number(right_number)) => {
-                Object::Number(left_number + right_number)
-            }
-            (Object::String(left_string), TokenType::Plus, Object::String(right_string)) => {
-                Object::String(left_string.clone() + &right_string)
-            }
-            (Object::Number(left_number), TokenType::Slash, Object::Number(right_number)) => {
-                Object::Number(left_number / right_number)
-            }
-            (Object::Number(left_number), TokenType::Star, Object::Number(right_number)) => {
-                Object::Number(left_number * right_number)
-            }
-            (left_object, TokenType::BangEqual, right_object) => {
-                Object::Boolean(!self.is_equal(&left_object, &right_object))
-            }
-            (left_object, TokenType::EqualEqual, right_object) => {
-                Object::Boolean(self.is_equal(&left_object, &right_object))
-            }
-            _ => unreachable!(), // TODO: handle other types
+        match &operator.tpe {
+            TokenType::Greater => match (l, r) {
+                (Object::Number(left_number), Object::Number(right_number)) => {
+                    Ok(Object::Boolean(left_number > right_number))
+                }
+                _ => self.number_operand_error(operator),
+            },
+            TokenType::GreaterEqual => match (l, r) {
+                (Object::Number(left_number), Object::Number(right_number)) => {
+                    Ok(Object::Boolean(left_number >= right_number))
+                }
+                _ => self.number_operand_error(operator),
+            },
+            TokenType::Less => match (l, r) {
+                (Object::Number(left_number), Object::Number(right_number)) => {
+                    Ok(Object::Boolean(left_number < right_number))
+                }
+                _ => self.number_operand_error(operator),
+            },
+            TokenType::LessEqual => match (l, r) {
+                (Object::Number(left_number), Object::Number(right_number)) => {
+                    Ok(Object::Boolean(left_number <= right_number))
+                }
+                _ => self.number_operand_error(operator),
+            },
+            TokenType::Minus => match (l, r) {
+                (Object::Number(left_number), Object::Number(right_number)) => {
+                    Ok(Object::Number(left_number - right_number))
+                }
+                _ => self.number_operand_error(operator),
+            },
+            TokenType::Plus => match (l, r) {
+                (Object::Number(left_number), Object::Number(right_number)) => {
+                    Ok(Object::Number(left_number + right_number))
+                }
+                (Object::String(left_string), Object::String(right_string)) => {
+                    Ok(Object::String(left_string.clone() + &right_string))
+                }
+                _ => Err(Error::Runtime {
+                    token: operator.clone(),
+                    message: "Operands must be two numbers or two strings.".to_string(),
+                }),
+            },
+            TokenType::Slash => match (l, r) {
+                (Object::Number(left_number), Object::Number(right_number)) => {
+                    Ok(Object::Number(left_number / right_number))
+                }
+                _ => self.number_operand_error(operator),
+            },
+            TokenType::Star => match (l, r) {
+                (Object::Number(left_number), Object::Number(right_number)) => {
+                    Ok(Object::Number(left_number * right_number))
+                }
+                _ => self.number_operand_error(operator),
+            },
+            TokenType::BangEqual => Ok(Object::Boolean(!self.is_equal(&l, &r))),
+            TokenType::EqualEqual => Ok(Object::Boolean(self.is_equal(&l, &r))),
+            _ => unreachable!(),
         }
     }
 
-    fn visit_grouping_expr(&self, expr: &Expr) -> Object {
+    fn visit_grouping_expr(&self, expr: &Expr) -> Result<Object, Error> {
         self.evaluate(expr)
     }
 
-    fn visit_literal_expr(&self, value: &LiteralValue) -> Object {
+    fn visit_literal_expr(&self, value: &LiteralValue) -> Result<Object, Error> {
         match value {
-            LiteralValue::Boolean(b) => Object::Boolean(b.clone()),
-            LiteralValue::Null => Object::Null,
-            LiteralValue::Number(n) => Object::Number(n.clone()),
-            LiteralValue::String(s) => Object::String(s.clone()),
+            LiteralValue::Boolean(b) => Ok(Object::Boolean(b.clone())),
+            LiteralValue::Null => Ok(Object::Null),
+            LiteralValue::Number(n) => Ok(Object::Number(n.clone())),
+            LiteralValue::String(s) => Ok(Object::String(s.clone())),
         }
     }
 
-    fn visit_unary_expr(&self, operator: &Token, right: &Expr) -> Object {
-        let right = self.evaluate(right);
+    fn visit_unary_expr(&self, operator: &Token, right: &Expr) -> Result<Object, Error> {
+        let right = self.evaluate(right)?;
 
-        match (&operator.tpe, &right) {
-            (TokenType::Minus, Object::Number(n)) => Object::Number(-n.clone()),
-            (TokenType::Bang, _) => Object::Boolean(!self.is_truthy(&right)), // TODO: is_truthy could simply return an Object.
+        match &operator.tpe {
+            TokenType::Minus => match right {
+                Object::Number(n) => Ok(Object::Number(-n.clone())),
+                _ => self.number_operand_error(operator),
+            },
+            TokenType::Bang => Ok(Object::Boolean(!self.is_truthy(&right))), // TODO: is_truthy could simply return an Object.
             _ => unreachable!(), // TODO: fail if right is not a number.
         }
     }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -27,6 +27,15 @@ impl Object {
 pub struct Interpreter;
 
 impl Interpreter {
+
+    fn interpret(&self, expression: &Expr) {
+        match self.evaluate(expression) {
+            Ok(value) => println!("{}", self.stringify(value)),
+            Err(_) => unimplemented!(),
+//            Err(e: Error::Runtime) => runtime_error(e),
+        }
+    }
+
     fn evaluate(&self, expression: &Expr) -> Result<Object, Error> {
         expression.accept(self)
     }
@@ -41,6 +50,15 @@ impl Interpreter {
 
     fn is_equal(&self, left: &Object, right: &Object) -> bool {
         left.equals(right)
+    }
+
+    fn stringify(&self, object: Object) -> String {
+        match object {
+            Object::Null => "nil".to_string(),
+            Object::Number(n) => n.to_string(),
+            Object::Boolean(b) => b.to_string(),
+            Object::String(s) => s,
+        }
     }
 
     /// Equivalent to checkNumberOperands

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -11,6 +11,13 @@ enum Object {
 
 pub struct Interpreter;
 
+impl Interpreter {
+
+    fn evaluate(&self, expression: &Expr) -> Object {
+        expression.accept(self)
+    }
+}
+
 impl Visitor<Object> for Interpreter { // TODO: Book defines result type as Object
 
     fn visit_binary_expr(&self, left: &Expr, operator: &Token, right: &Expr) -> Object {
@@ -18,7 +25,7 @@ impl Visitor<Object> for Interpreter { // TODO: Book defines result type as Obje
     }
 
     fn visit_grouping_expr(&self, expr: &Expr) -> Object {
-        unimplemented!()
+        self.evaluate(expr)
     }
 
     fn visit_literal_expr(&self, value: &LiteralValue) -> Object {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,45 +10,63 @@ use std::process::exit;
 use std::{env, fs};
 
 use error::Error;
+use interpreter::Interpreter;
 use parser::Parser;
 use scanner::Scanner;
 use syntax::AstPrinter;
 
+struct Lox {
+    interpreter: Interpreter,
+}
+
+impl Lox {
+    fn new() -> Self {
+        Lox {
+            interpreter: Interpreter,
+        }
+    }
+
+    fn run_file(&self, path: &str) -> Result<(), Error> {
+        let source = fs::read_to_string(path)?;
+        self.run(source)
+    }
+
+    fn run_prompt(&self) -> Result<(), Error> {
+        let stdin = io::stdin();
+        for line in stdin.lock().lines() {
+            self.run(line?); // Ignore error.
+            print!("> ");
+        }
+        Ok(())
+    }
+
+    fn run(&self, source: String) -> Result<(), Error> {
+        let mut scanner = Scanner::new(source);
+        let tokens = scanner.scan_tokens();
+
+        let mut parser = Parser::new(tokens);
+        if let Some(expression) = parser.parse() {
+            println!("{}", self.interpreter.interpret(&expression)?);
+        }
+        Ok(())
+    }
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     let args: Vec<String> = env::args().collect();
+    let lox = Lox::new();
     match args.as_slice() {
-        [_, file] => run_file(file)?,
-        [_] => run_prompt()?,
+        [_, file] => match lox.run_file(file) {
+            Ok(_) => (),
+            Err(Error::Runtime { .. }) => exit(70),
+            Err(Error::Parse) => exit(65),
+            Err(Error::Io(_)) => unimplemented!(),
+        },
+        [_] => lox.run_prompt()?,
         _ => {
             eprintln!("Usage: lox-rs [script]");
             exit(64)
         }
-    }
-    Ok(())
-}
-
-fn run_file(path: &str) -> Result<(), Error> {
-    let source = fs::read_to_string(path)?;
-    run(source)
-}
-
-fn run_prompt() -> Result<(), Error> {
-    let stdin = io::stdin();
-    for line in stdin.lock().lines() {
-        run(line?); // Ignore error.
-        print!("> ");
-    }
-    Ok(())
-}
-
-fn run(source: String) -> Result<(), Error> {
-    let mut scanner = Scanner::new(source);
-    let tokens = scanner.scan_tokens();
-
-    let mut parser = Parser::new(tokens);
-    if let Some(expression) = parser.parse() {
-        let printer = AstPrinter;
-        println!("{}", printer.print(expression)?);
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod error;
+mod interpreter;
 mod parser;
 mod scanner;
 mod syntax;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use std::io::{self, BufRead};
 use std::process::exit;
 use std::{env, fs};
 
+use error::Error;
 use parser::Parser;
 use scanner::Scanner;
 use syntax::AstPrinter;
@@ -26,12 +27,12 @@ fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     Ok(())
 }
 
-fn run_file(path: &str) -> io::Result<()> {
+fn run_file(path: &str) -> Result<(), Error> {
     let source = fs::read_to_string(path)?;
     run(source)
 }
 
-fn run_prompt() -> io::Result<()> {
+fn run_prompt() -> Result<(), Error> {
     let stdin = io::stdin();
     for line in stdin.lock().lines() {
         run(line?); // Ignore error.
@@ -40,14 +41,14 @@ fn run_prompt() -> io::Result<()> {
     Ok(())
 }
 
-fn run(source: String) -> io::Result<()> {
+fn run(source: String) -> Result<(), Error> {
     let mut scanner = Scanner::new(source);
     let tokens = scanner.scan_tokens();
 
     let mut parser = Parser::new(tokens);
     if let Some(expression) = parser.parse() {
         let printer = AstPrinter;
-        println!("{}", printer.print(expression));
+        println!("{}", printer.print(expression)?);
     }
     Ok(())
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -232,6 +232,6 @@ mod tests {
         let expression = parser.parse().expect("Could not parse sample code.");
         let printer = AstPrinter;
 
-        assert_eq!(printer.print(expression), "(* (- 123) 45.67)");
+        assert_eq!(printer.print(expression).unwrap(), "(* (- 123) 45.67)");
     }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -40,7 +40,7 @@ impl fmt::Display for LiteralValue {
 pub trait Visitor<R> {
     fn visit_binary_expr(&self, left: &Expr, operator: &Token, right: &Expr) -> R;
     fn visit_grouping_expr(&self, expression: &Expr) -> R;
-    fn visit_literal_expr(&self, value: String) -> R;
+    fn visit_literal_expr(&self, value: &LiteralValue) -> R;
     fn visit_unary_expr(&self, operator: &Token, right: &Expr) -> R;
 }
 
@@ -53,7 +53,7 @@ impl Expr {
                 right,
             } => visitor.visit_binary_expr(left, operator, right),
             Expr::Grouping { expression } => visitor.visit_grouping_expr(expression),
-            Expr::Literal { value } => visitor.visit_literal_expr(value.to_string()),
+            Expr::Literal { value } => visitor.visit_literal_expr(value),
             Expr::Unary { operator, right } => visitor.visit_unary_expr(operator, right),
         }
     }
@@ -88,8 +88,8 @@ impl Visitor<String> for AstPrinter {
         self.parenthesize("group".to_string(), vec![expr])
     }
 
-    fn visit_literal_expr(&self, value: String) -> String {
-        value // check for null
+    fn visit_literal_expr(&self, value: &LiteralValue) -> String {
+        value.to_string() // check for null
     }
 
     fn visit_unary_expr(&self, operator: &Token, right: &Expr) -> String {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -39,6 +39,12 @@ impl fmt::Display for LiteralValue {
 
 pub trait Visitor<R> {
     fn visit_binary_expr(&self, left: &Expr, operator: &Token, right: &Expr) -> R;
+
+    /// Visit a grouping expression.
+    ///
+    /// # Arguments
+    ///
+    /// * `expression` - This is the *inner* expression of the grouping.
     fn visit_grouping_expr(&self, expression: &Expr) -> R;
     fn visit_literal_expr(&self, value: &LiteralValue) -> R;
     fn visit_unary_expr(&self, operator: &Token, right: &Expr) -> R;


### PR DESCRIPTION
This implements [chapter 7](http://craftinginterpreters.com/evaluating-expressions.html).
We introduce a simple evaluation of some basic operators.

The biggest difference to the original Java version is that we are not setting `hadRuntimeError`
but return a `Result<String, Error>` from the `interpret` function.

The Java version also casts the literal to `String` or `Double` and handles exceptions. In Rust
we can simply pattern match and return a `Error::Runtime` when `+` is called for other types.