### PR TITLE
Chapter 8: Statements and State

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A [Lox](http://craftinginterpreters.com/the-lox-language.html) Interpreter in Ru
 
 Each commit corresponds to one chapter in the book:
 
-* [Chapter 4](https://github.com/jeschkies/lox-rs/commit/9fef15e73fdf57a3e428bb074059c7e144e257f7)
-* [Chapter 5](https://github.com/jeschkies/lox-rs/commit/0156a95b4bf448dbff9cb4341a2339b741a163ca)
-* [Chapter 6](https://github.com/jeschkies/lox-rs/commit/9508c9d887a88540597d314520ae6aa045256e7d)
+* [Chapter 4: Scanning](https://github.com/jeschkies/lox-rs/commit/9fef15e73fdf57a3e428bb074059c7e144e257f7)
+* [Chapter 5: Representing Code](https://github.com/jeschkies/lox-rs/commit/0156a95b4bf448dbff9cb4341a2339b741a163ca)
+* [Chapter 6: Parsing Expressions](https://github.com/jeschkies/lox-rs/commit/9508c9d887a88540597d314520ae6aa045256e7d)
+* [Chapter 7: Evaluating Expressions](https://github.com/jeschkies/lox-rs/commit/fd90ef985c88832c9af6f193e0614e41dd13ef28)

--- a/src/env.rs
+++ b/src/env.rs
@@ -31,6 +31,19 @@ impl Environment {
             })
         }
     }
+
+    pub fn assign(&mut self, name: &Token, value: Object) -> Result<(), Error> {
+        let key = &*name.lexeme;
+        if self.values.contains_key(key) {
+            self.values.insert(name.lexeme.clone(), value);
+            Ok(())
+        } else {
+            Err(Error::Runtime {
+                token: name.clone(),
+                message: format!("Undefined variable '{}'", key),
+            })
+        }
+    }
 }
 
 impl fmt::Display for Environment {

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,0 +1,40 @@
+use crate::error::Error;
+use crate::object::Object;
+use crate::token::Token;
+
+use std::collections::HashMap;
+use std::fmt;
+
+pub struct Environment {
+    values: HashMap<String, Object>,
+}
+
+impl Environment {
+    pub fn new() -> Self {
+        Environment {
+            values: HashMap::new(),
+        }
+    }
+
+    pub fn define(&mut self, name: String, value: Object) {
+        self.values.insert(name, value);
+    }
+
+    pub fn get(&self, name: &Token) -> Result<Object, Error> {
+        let key = &*name.lexeme;
+        if let Some(value) = self.values.get(key) {
+            Ok((*value).clone())
+        } else {
+            Err(Error::Runtime {
+                token: name.clone(),
+                message: format!("Undefined variable '{}'.", key),
+            })
+        }
+    }
+}
+
+impl fmt::Display for Environment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "values: {:?}", self.values)
+    }
+}

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,5 +1,6 @@
 use crate::error::Error;
-use crate::syntax::{Expr, LiteralValue, Visitor};
+use crate::syntax::expr::Visitor;
+use crate::syntax::{Expr, LiteralValue};
 use crate::token::{Token, TokenType};
 
 /// A simple representation of an Lox object akin to a Java `Object`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,9 +45,8 @@ impl Lox {
         let tokens = scanner.scan_tokens();
 
         let mut parser = Parser::new(tokens);
-        if let Some(expression) = parser.parse() {
-            println!("{}", self.interpreter.interpret(&expression)?);
-        }
+        let statements = parser.parse()?;
+        self.interpreter.interpret(&statements)?;
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,15 @@
+mod env;
 mod error;
 mod interpreter;
+mod object;
 mod parser;
 mod scanner;
 mod syntax;
 mod token;
 
+use std::fs;
 use std::io::{self, BufRead};
 use std::process::exit;
-use std::{env, fs};
 
 use error::Error;
 use interpreter::Interpreter;
@@ -22,16 +24,16 @@ struct Lox {
 impl Lox {
     fn new() -> Self {
         Lox {
-            interpreter: Interpreter,
+            interpreter: Interpreter::new(),
         }
     }
 
-    fn run_file(&self, path: &str) -> Result<(), Error> {
+    fn run_file(&mut self, path: &str) -> Result<(), Error> {
         let source = fs::read_to_string(path)?;
         self.run(source)
     }
 
-    fn run_prompt(&self) -> Result<(), Error> {
+    fn run_prompt(&mut self) -> Result<(), Error> {
         let stdin = io::stdin();
         for line in stdin.lock().lines() {
             self.run(line?); // Ignore error.
@@ -40,7 +42,7 @@ impl Lox {
         Ok(())
     }
 
-    fn run(&self, source: String) -> Result<(), Error> {
+    fn run(&mut self, source: String) -> Result<(), Error> {
         let mut scanner = Scanner::new(source);
         let tokens = scanner.scan_tokens();
 
@@ -52,8 +54,8 @@ impl Lox {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
-    let args: Vec<String> = env::args().collect();
-    let lox = Lox::new();
+    let args: Vec<String> = std::env::args().collect();
+    let mut lox = Lox::new();
     match args.as_slice() {
         [_, file] => match lox.run_file(file) {
             Ok(_) => (),

--- a/src/object.rs
+++ b/src/object.rs
@@ -1,0 +1,22 @@
+/// A simple representation of an Lox object akin to a Java `Object`.
+#[derive(Debug, Clone)]
+pub enum Object {
+    Boolean(bool),
+    Null,
+    Number(f64),
+    String(String),
+}
+
+impl Object {
+    pub fn equals(&self, other: &Object) -> bool {
+        match (self, other) {
+            (Object::Null, Object::Null) => true,
+            (_, Object::Null) => false,
+            (Object::Null, _) => false,
+            (Object::Boolean(left), Object::Boolean(right)) => left == right,
+            (Object::Number(left), Object::Number(right)) => left == right,
+            (Object::String(left), Object::String(right)) => left.eq(right),
+            _ => false,
+        }
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -80,7 +80,7 @@ impl<'t> Parser<'t> {
         self.consume(
             TokenType::Semicolon,
             "Expect ';' after variable declaration.",
-        );
+        )?;
         Ok(Stmt::Var { name, initializer })
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -57,6 +57,10 @@ impl<'t> Parser<'t> {
     fn statement(&mut self) -> Result<Stmt, Error> {
         if matches!(self, TokenType::Print) {
             self.print_statement()
+        } else if matches!(self, TokenType::LeftBrace) {
+            Ok(Stmt::Block {
+                statements: self.block()?,
+            })
         } else {
             self.expression_statement()
         }
@@ -88,6 +92,17 @@ impl<'t> Parser<'t> {
         let expr = self.expression()?;
         self.consume(TokenType::Semicolon, "Expect ';' after expression.")?;
         Ok(Stmt::Expression { expression: expr })
+    }
+
+    fn block(&mut self) -> Result<Vec<Stmt>, Error> {
+        let mut statements: Vec<Stmt> = Vec::new();
+
+        while !self.check(TokenType::RightBrace) && !self.is_at_end() {
+            statements.push(self.declaration()?);
+        }
+
+        self.consume(TokenType::RightBrace, "Expect '}' after block.")?;
+        Ok(statements)
     }
 
     fn assignment(&mut self) -> Result<Expr, Error> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -46,11 +46,11 @@ impl<'t> Parser<'t> {
         };
 
         match statement {
-            Ok(statement) => Ok(statement),
             Err(Error::Parse) => {
                 self.synchronize();
                 Ok(Stmt::Null)
-            }
+            },
+            other => other
         }
     }
 
@@ -257,10 +257,9 @@ impl<'t> Parser<'t> {
             TokenType::Number { literal } => Expr::Literal {
                 value: LiteralValue::Number(literal.clone()),
             },
-            TokenType::Identifier => {
-                Expr::Variable { name: self.previous().clone() }
-                
-            }
+            TokenType::Identifier => Expr::Variable {
+                name: self.peek().clone(),
+            },
             TokenType::LeftParen => {
                 let expr = self.expression()?;
                 self.consume(TokenType::RightParen, "Expected ')' after expression.")?;

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -2,6 +2,7 @@ use crate::error::Error;
 use crate::token::Token;
 use std::fmt;
 
+#[derive(Debug, Clone)]
 pub enum Expr {
     Binary {
         left: Box<Expr>,
@@ -23,6 +24,7 @@ pub enum Expr {
     },
 }
 
+#[derive(Debug, Clone)]
 pub enum LiteralValue {
     Boolean(bool),
     Null,
@@ -38,6 +40,12 @@ impl fmt::Display for LiteralValue {
             LiteralValue::Number(n) => write!(f, "{}", n),
             LiteralValue::String(s) => write!(f, "{}", s),
         }
+    }
+}
+
+impl fmt::Display for Expr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 
@@ -96,15 +104,17 @@ pub enum Stmt {
         name: Token,
         initializer: Option<Expr>,
     },
+    Null, // TODO see how stmt is handled after synchronize
 }
 
 impl Stmt {
-    pub fn accept<R>(&self, visitor: &stmt::Visitor<R>) -> Result<R, Error> {
+    pub fn accept<R>(&self, visitor: &mut stmt::Visitor<R>) -> Result<R, Error> {
         match self {
             Stmt::Block { statements } => visitor.visit_block_stmt(statements),
             Stmt::Expression { expression } => visitor.visit_expression_stmt(expression),
             Stmt::Print { expression } => visitor.visit_print_stmt(expression),
             Stmt::Var { name, initializer } => visitor.visit_var_stmt(name, initializer),
+            Stmt::Null => unimplemented!(),
         }
     }
 }
@@ -122,7 +132,7 @@ pub mod stmt {
         //        fn visit_if_stmt(&self, If stmt); TODO: Control Flows chapter
         fn visit_print_stmt(&self, expression: &Expr) -> Result<R, Error>;
         //        fn visit_return_stmt(&self, Return stmt); TODO: Functions chapter
-        fn visit_var_stmt(&self, name: &Token, initializer: &Option<Expr>) -> Result<R, Error>;
+        fn visit_var_stmt(&mut self, name: &Token, initializer: &Option<Expr>) -> Result<R, Error>;
         //        fn visit_while_stmt(&self, While stmt); TODO: Control Flows chapter
     }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -18,6 +18,9 @@ pub enum Expr {
         operator: Token,
         right: Box<Expr>,
     },
+    Variable {
+        name: Token,
+    },
 }
 
 pub enum LiteralValue {
@@ -49,6 +52,7 @@ impl Expr {
             Expr::Grouping { expression } => visitor.visit_grouping_expr(expression),
             Expr::Literal { value } => visitor.visit_literal_expr(value),
             Expr::Unary { operator, right } => visitor.visit_unary_expr(operator, right),
+            Expr::Variable { name } => visitor.visit_variable_expr(name),
         }
     }
 }
@@ -74,14 +78,24 @@ pub mod expr {
         fn visit_grouping_expr(&self, expression: &Expr) -> Result<R, Error>;
         fn visit_literal_expr(&self, value: &LiteralValue) -> Result<R, Error>;
         fn visit_unary_expr(&self, operator: &Token, right: &Expr) -> Result<R, Error>;
+        fn visit_variable_expr(&self, name: &Token) -> Result<R, Error>;
     }
 }
 
 pub enum Stmt {
-    Block { statements: Vec<Stmt> },
-    Expression { expression: Expr },
-    Print { expression: Expr },
-    Var { name: Token, initializer: Expr },
+    Block {
+        statements: Vec<Stmt>,
+    },
+    Expression {
+        expression: Expr,
+    },
+    Print {
+        expression: Expr,
+    },
+    Var {
+        name: Token,
+        initializer: Option<Expr>,
+    },
 }
 
 impl Stmt {
@@ -108,7 +122,7 @@ pub mod stmt {
         //        fn visit_if_stmt(&self, If stmt); TODO: Control Flows chapter
         fn visit_print_stmt(&self, expression: &Expr) -> Result<R, Error>;
         //        fn visit_return_stmt(&self, Return stmt); TODO: Functions chapter
-        fn visit_var_stmt(&self, name: &Token, initializer: &Expr) -> Result<R, Error>;
+        fn visit_var_stmt(&self, name: &Token, initializer: &Option<Expr>) -> Result<R, Error>;
         //        fn visit_while_stmt(&self, While stmt); TODO: Control Flows chapter
     }
 }
@@ -153,6 +167,10 @@ impl expr::Visitor<String> for AstPrinter {
 
     fn visit_unary_expr(&self, operator: &Token, right: &Expr) -> Result<String, Error> {
         self.parenthesize(operator.lexeme.clone(), vec![right])
+    }
+
+    fn visit_variable_expr(&self, name: &Token) -> Result<String, Error> {
+        Ok(name.lexeme.clone())
     }
 }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -79,21 +79,37 @@ pub mod expr {
 
 pub enum Stmt {
     Block { statements: Vec<Stmt> },
+    Expression { expression: Expr },
+    Print { expression: Expr },
+    Var { name: Token, initializer: Expr },
 }
 
 impl Stmt {
     pub fn accept<R>(&self, visitor: &stmt::Visitor<R>) -> Result<R, Error> {
         match self {
-            Stmt::Block { statements } => visitor.visit_block(statements),
+            Stmt::Block { statements } => visitor.visit_block_stmt(statements),
+            Stmt::Expression { expression } => visitor.visit_expression_stmt(expression),
+            Stmt::Print { expression } => visitor.visit_print_stmt(expression),
+            Stmt::Var { name, initializer } => visitor.visit_var_stmt(name, initializer),
         }
     }
 }
 
 mod stmt {
+    use super::{Expr, Stmt};
     use crate::error::Error;
+    use crate::token::Token;
 
     pub trait Visitor<R> {
-        fn visit_block(&self, statements: &Vec<super::Stmt>) -> Result<R, Error>;
+        fn visit_block_stmt(&self, statements: &Vec<Stmt>) -> Result<R, Error>;
+        //        fn visit_class_stmt(&self, Class stmt); TODO: Classes chapter
+        fn visit_expression_stmt(&self, expression: &Expr) -> Result<R, Error>;
+        //        fn visit_function_stmt(&self, Function stmt); TODO: Functions chapter
+        //        fn visit_if_stmt(&self, If stmt); TODO: Control Flows chapter
+        fn visit_print_stmt(&self, expression: &Expr) -> Result<R, Error>;
+        //        fn visit_return_stmt(&self, Return stmt); TODO: Functions chapter
+        fn visit_var_stmt(&self, name: &Token, initializer: &Expr) -> Result<R, Error>;
+        //        fn visit_while_stmt(&self, While stmt); TODO: Control Flows chapter
     }
 }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -95,7 +95,7 @@ impl Stmt {
     }
 }
 
-mod stmt {
+pub mod stmt {
     use super::{Expr, Stmt};
     use crate::error::Error;
     use crate::token::Token;


### PR DESCRIPTION
This implements [statements and state](http://craftinginterpreters.com/statements-and-state.html).

It introduces nested environments with a reference to its parent. The visitors for statements and
expressions are moved into `expr` and `stmt` modules.

The code differs not too much from the original
* We still use `Result` instead of exceptions.
* Since there is not try-catch in Rust we use a lambda.
* Handling mutable references to parent environments requires `Rc` and `RefCell`.