### PR TITLE
Chapter 9: Control Flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Each commit corresponds to one chapter in the book:
 * [Chapter 5: Representing Code](https://github.com/jeschkies/lox-rs/commit/0156a95b4bf448dbff9cb4341a2339b741a163ca)
 * [Chapter 6: Parsing Expressions](https://github.com/jeschkies/lox-rs/commit/9508c9d887a88540597d314520ae6aa045256e7d)
 * [Chapter 7: Evaluating Expressions](https://github.com/jeschkies/lox-rs/commit/fd90ef985c88832c9af6f193e0614e41dd13ef28)
+* [Chapter 8: Statements and State](https://github.com/jeschkies/lox-rs/commit/941cbba900acb5876dbe6031b24ef31ff81ca99e)

--- a/examples/loop.lox
+++ b/examples/loop.lox
@@ -1,0 +1,9 @@
+var a = 0;
+var b = 1;
+
+while (a < 10000) {
+  print a;
+  var temp = a;
+  a = b;
+  b = temp + b;
+}

--- a/examples/scope.lox
+++ b/examples/scope.lox
@@ -1,0 +1,20 @@
+var a = "global a";
+var b = "global b";
+var c = "global c";
+{
+  var a = "outer a";
+  var b = "outer b";
+  {
+    var a = "inner a";
+    print a;
+    print b;
+    print c;
+  }
+  print a;
+  print b;
+  print c;
+}
+print a;
+print b;
+print c;
+

--- a/examples/simple.lox
+++ b/examples/simple.lox
@@ -1,0 +1,3 @@
+print "one";
+print true;
+print 2 + 1;

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -204,6 +204,17 @@ impl stmt::Visitor<()> for Interpreter {
         Ok(())
     }
 
+    fn visit_if_stmt(&mut self, condition: &Expr, else_branch: &Option<Stmt>, then_branch: &Stmt) -> Result<(), Error> {
+        let condition_value = self.evaluate(condition)?;
+        if self.is_truthy(&condition_value) {
+           self.execute(then_branch)?;
+        } else if let Some(other) = else_branch {
+           self.execute(other)?;
+        }
+
+        Ok(())
+    }
+
     fn visit_print_stmt(&mut self, expression: &Expr) -> Result<(), Error> {
         let value = self.evaluate(expression)?;
         println!("{}", self.stringify(value));
@@ -216,7 +227,9 @@ impl stmt::Visitor<()> for Interpreter {
             .map(|i| self.evaluate(i))
             .unwrap_or(Ok(Object::Null))?;
 
-        self.environment.borrow_mut().define(name.lexeme.clone(), value);
+        self.environment
+            .borrow_mut()
+            .define(name.lexeme.clone(), value);
         Ok(())
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -259,9 +259,10 @@ impl stmt::Visitor<()> for Interpreter {
     }
 
     fn visit_while_stmt(&mut self, condition: &Expr, body: &Stmt) -> Result<(), Error> {
-        let value = self.evaluate(condition)?;
+        let mut value = self.evaluate(condition)?;
         while self.is_truthy(&value) {
             self.execute(body)?;
+            value = self.evaluate(condition)?
         }
 
         Ok(())

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -257,4 +257,13 @@ impl stmt::Visitor<()> for Interpreter {
             .define(name.lexeme.clone(), value);
         Ok(())
     }
+
+    fn visit_while_stmt(&mut self, condition: &Expr, body: &Stmt) -> Result<(), Error> {
+        let value = self.evaluate(condition)?;
+        while self.is_truthy(&value) {
+            self.execute(body)?;
+        }
+
+        Ok(())
+    }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -166,6 +166,26 @@ impl expr::Visitor<Object> for Interpreter {
         }
     }
 
+    fn visit_logical_expr(
+        &mut self,
+        left: &Expr,
+        operator: &Token,
+        right: &Expr,
+    ) -> Result<Object, Error> {
+        let l = self.evaluate(left)?;
+
+        if operator.tpe == TokenType::Or {
+            if self.is_truthy(&l) {
+                return Ok(l);
+            }
+        } else {
+            if !self.is_truthy(&l) {
+                return Ok(l);
+            }
+        }
+        self.evaluate(right)
+    }
+
     fn visit_unary_expr(&mut self, operator: &Token, right: &Expr) -> Result<Object, Error> {
         let right = self.evaluate(right)?;
 
@@ -204,12 +224,17 @@ impl stmt::Visitor<()> for Interpreter {
         Ok(())
     }
 
-    fn visit_if_stmt(&mut self, condition: &Expr, else_branch: &Option<Stmt>, then_branch: &Stmt) -> Result<(), Error> {
+    fn visit_if_stmt(
+        &mut self,
+        condition: &Expr,
+        else_branch: &Option<Stmt>,
+        then_branch: &Stmt,
+    ) -> Result<(), Error> {
         let condition_value = self.evaluate(condition)?;
         if self.is_truthy(&condition_value) {
-           self.execute(then_branch)?;
+            self.execute(then_branch)?;
         } else if let Some(other) = else_branch {
-           self.execute(other)?;
+            self.execute(other)?;
         }
 
         Ok(())

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -59,6 +59,8 @@ impl<'t> Parser<'t> {
             self.if_statement()
         } else if matches!(self, TokenType::Print) {
             self.print_statement()
+        } else if matches!(self, TokenType::While) {
+            self.while_statement()
         } else if matches!(self, TokenType::LeftBrace) {
             Ok(Stmt::Block {
                 statements: self.block()?,
@@ -107,6 +109,14 @@ impl<'t> Parser<'t> {
             "Expect ';' after variable declaration.",
         )?;
         Ok(Stmt::Var { name, initializer })
+    }
+
+    fn while_statement(&mut self) -> Result<Stmt, Error> {
+        self.consume(TokenType::LeftParen, "Expect '(' after 'while'.")?;
+        let condition = self.expression()?;
+        self.consume(TokenType::RightParen, "Expect ')' after condition.")?;
+        let body = Box::new(self.statement()?);
+        Ok(Stmt::While { condition, body })
     }
 
     fn expression_statement(&mut self) -> Result<Stmt, Error> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -55,7 +55,9 @@ impl<'t> Parser<'t> {
     }
 
     fn statement(&mut self) -> Result<Stmt, Error> {
-        if matches!(self, TokenType::Print) {
+        if matches!(self, TokenType::If) {
+            self.if_statement()
+        } else if matches!(self, TokenType::Print) {
             self.print_statement()
         } else if matches!(self, TokenType::LeftBrace) {
             Ok(Stmt::Block {
@@ -64,6 +66,25 @@ impl<'t> Parser<'t> {
         } else {
             self.expression_statement()
         }
+    }
+
+    fn if_statement(&mut self) -> Result<Stmt, Error> {
+        self.consume(TokenType::LeftParen, "Expect '(' after 'if'.")?;
+        let condition = self.expression()?;
+        self.consume(TokenType::RightParen, "Expect ')' after if condition.")?;
+
+        let then_branch = Box::new(self.statement()?);
+        let else_branch = if matches!(self, TokenType::Else) {
+            Box::new(Some(self.statement()?))
+        } else {
+            Box::new(None)
+        };
+
+        Ok(Stmt::If {
+            condition,
+            else_branch,
+            then_branch,
+        })
     }
 
     fn print_statement(&mut self) -> Result<Stmt, Error> {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -19,6 +19,11 @@ pub enum Expr {
     Literal {
         value: LiteralValue,
     },
+    Logical {
+        left: Box<Expr>,
+        operator: Token,
+        right: Box<Expr>,
+    },
     Unary {
         operator: Token,
         right: Box<Expr>,
@@ -64,6 +69,11 @@ impl Expr {
             } => visitor.visit_binary_expr(left, operator, right),
             Expr::Grouping { expression } => visitor.visit_grouping_expr(expression),
             Expr::Literal { value } => visitor.visit_literal_expr(value),
+            Expr::Logical {
+                left,
+                operator,
+                right,
+            } => visitor.visit_logical_expr(left, operator, right),
             Expr::Unary { operator, right } => visitor.visit_unary_expr(operator, right),
             Expr::Variable { name } => visitor.visit_variable_expr(name),
         }
@@ -91,6 +101,12 @@ pub mod expr {
         /// * `expression` - This is the *inner* expression of the grouping.
         fn visit_grouping_expr(&mut self, expression: &Expr) -> Result<R, Error>;
         fn visit_literal_expr(&self, value: &LiteralValue) -> Result<R, Error>;
+        fn visit_logical_expr(
+            &mut self,
+            left: &Expr,
+            operator: &Token,
+            right: &Expr,
+        ) -> Result<R, Error>;
         fn visit_unary_expr(&mut self, operator: &Token, right: &Expr) -> Result<R, Error>;
         fn visit_variable_expr(&mut self, name: &Token) -> Result<R, Error>;
     }
@@ -194,6 +210,15 @@ impl expr::Visitor<String> for AstPrinter {
 
     fn visit_literal_expr(&self, value: &LiteralValue) -> Result<String, Error> {
         Ok(value.to_string()) // check for null
+    }
+
+    fn visit_logical_expr(
+        &mut self,
+        left: &Expr,
+        operator: &Token,
+        right: &Expr,
+    ) -> Result<String, Error> {
+        self.parenthesize(operator.lexeme.clone(), vec![left, right])
     }
 
     fn visit_unary_expr(&mut self, operator: &Token, right: &Expr) -> Result<String, Error> {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -131,6 +131,10 @@ pub enum Stmt {
         name: Token,
         initializer: Option<Expr>,
     },
+    While {
+        condition: Expr,
+        body: Box<Stmt>,
+    },
     Null, // TODO see how stmt is handled after synchronize
 }
 
@@ -146,6 +150,7 @@ impl Stmt {
             } => visitor.visit_if_stmt(condition, else_branch, then_branch),
             Stmt::Print { expression } => visitor.visit_print_stmt(expression),
             Stmt::Var { name, initializer } => visitor.visit_var_stmt(name, initializer),
+            Stmt::While { condition, body } => visitor.visit_while_stmt(condition, body),
             Stmt::Null => unimplemented!(),
         }
     }
@@ -170,7 +175,7 @@ pub mod stmt {
         fn visit_print_stmt(&mut self, expression: &Expr) -> Result<R, Error>;
         //        fn visit_return_stmt(&self, Return stmt); TODO: Functions chapter
         fn visit_var_stmt(&mut self, name: &Token, initializer: &Option<Expr>) -> Result<R, Error>;
-        //        fn visit_while_stmt(&self, While stmt); TODO: Control Flows chapter
+        fn visit_while_stmt(&mut self, condition: &Expr, body: &Stmt) -> Result<R, Error>;
     }
 }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -103,6 +103,11 @@ pub enum Stmt {
     Expression {
         expression: Expr,
     },
+    If {
+        condition: Expr,
+        else_branch: Box<Option<Stmt>>,
+        then_branch: Box<Stmt>,
+    },
     Print {
         expression: Expr,
     },
@@ -118,6 +123,11 @@ impl Stmt {
         match self {
             Stmt::Block { statements } => visitor.visit_block_stmt(statements),
             Stmt::Expression { expression } => visitor.visit_expression_stmt(expression),
+            Stmt::If {
+                condition,
+                else_branch,
+                then_branch,
+            } => visitor.visit_if_stmt(condition, else_branch, then_branch),
             Stmt::Print { expression } => visitor.visit_print_stmt(expression),
             Stmt::Var { name, initializer } => visitor.visit_var_stmt(name, initializer),
             Stmt::Null => unimplemented!(),
@@ -135,7 +145,12 @@ pub mod stmt {
         //        fn visit_class_stmt(&self, Class stmt); TODO: Classes chapter
         fn visit_expression_stmt(&mut self, expression: &Expr) -> Result<R, Error>;
         //        fn visit_function_stmt(&self, Function stmt); TODO: Functions chapter
-        //        fn visit_if_stmt(&self, If stmt); TODO: Control Flows chapter
+        fn visit_if_stmt(
+            &mut self,
+            condition: &Expr,
+            else_branch: &Option<Stmt>,
+            then_branch: &Stmt,
+        ) -> Result<R, Error>;
         fn visit_print_stmt(&mut self, expression: &Expr) -> Result<R, Error>;
         //        fn visit_return_stmt(&self, Return stmt); TODO: Functions chapter
         fn visit_var_stmt(&mut self, name: &Token, initializer: &Option<Expr>) -> Result<R, Error>;


### PR DESCRIPTION
This implements [chapter 9](http://craftinginterpreters.com/control-flow.html).

Most code should be a straight forward translation. Rust's `Option` and `if let` makes it easy
to handle the cases when there is an initializer or not in a loop.