### PR TITLE
Chapter 11: Resolving and Binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ Each commit corresponds to one chapter in the book:
   * [Chapter 7: Evaluating Expressions](https://github.com/jeschkies/lox-rs/commit/fd90ef985c88832c9af6f193e0614e41dd13ef28)
   * [Chapter 8: Statements and State](https://github.com/jeschkies/lox-rs/commit/941cbba900acb5876dbe6031b24ef31ff81ca99e)
   * [Chapter 9: Control Flow](https://github.com/jeschkies/lox-rs/commit/d1f8d67f65fa4d66e24e654fec7bd8d1529b124d)
+  * [Chapter 10: Functions](https://github.com/jeschkies/lox-rs/commit/0e10d13944a6cd77d37f9cdf393ed81ba9573172)

--- a/examples/inner_outer.lox
+++ b/examples/inner_outer.lox
@@ -1,0 +1,10 @@
+var a = "global";
+{
+  fun showA() {
+    print a;
+  }
+
+  showA();
+  var a = "block";
+  showA();
+}

--- a/examples/scope.lox
+++ b/examples/scope.lox
@@ -18,3 +18,13 @@ print a;
 print b;
 print c;
 
+var a = "global";
+{
+  fun showA() {
+    print a;
+  }
+
+  showA();
+  var a = "block";
+  showA();
+}

--- a/examples/scope.lox
+++ b/examples/scope.lox
@@ -17,14 +17,3 @@ var c = "global c";
 print a;
 print b;
 print c;
-
-var a = "global";
-{
-  fun showA() {
-    print a;
-  }
-
-  showA();
-  var a = "block";
-  showA();
-}

--- a/src/env.rs
+++ b/src/env.rs
@@ -31,8 +31,36 @@ impl Environment {
         self.values.insert(name, value);
     }
 
+    fn ancestor(&self, distance: usize) -> Rc<RefCell<Environment>> {
+        // Get first ancestor
+        let parent= self.enclosing.clone().expect(&format!("No enclosing environment at {}", 1));
+        let mut environment = Rc::clone(&parent);
+
+        // Get next ancestors
+        for i in 1..distance {
+            let parent= self.enclosing.clone().expect(&format!("No enclosing environment at {}", i));
+            environment = Rc::clone(&parent);
+        }
+        environment
+    }
+
     pub fn get_at(&self, distance: usize, name: &Token) -> Result<Object, Error> {
-        unimplemented!()
+        let key = &*name.lexeme;
+        Ok(self
+            .ancestor(distance)
+            .borrow()
+            .values
+            .get(key)
+            .expect(&format!("Undefined variable '{}'", key))
+            .clone())
+    }
+
+    pub fn assign_at(&mut self, distance: usize, name: &Token, value: Object) -> Result<(), Error> {
+        self.ancestor(distance)
+            .borrow_mut()
+            .values
+            .insert(name.lexeme.clone(), value);
+        Ok(())
     }
 
     pub fn get(&self, name: &Token) -> Result<Object, Error> {

--- a/src/env.rs
+++ b/src/env.rs
@@ -33,12 +33,18 @@ impl Environment {
 
     fn ancestor(&self, distance: usize) -> Rc<RefCell<Environment>> {
         // Get first ancestor
-        let parent= self.enclosing.clone().expect(&format!("No enclosing environment at {}", 1));
+        let parent = self
+            .enclosing
+            .clone()
+            .expect(&format!("No enclosing environment at {}", 1));
         let mut environment = Rc::clone(&parent);
 
         // Get next ancestors
         for i in 1..distance {
-            let parent= self.enclosing.clone().expect(&format!("No enclosing environment at {}", i));
+            let parent = self
+                .enclosing
+                .clone()
+                .expect(&format!("No enclosing environment at {}", i));
             environment = Rc::clone(&parent);
         }
         environment
@@ -46,20 +52,32 @@ impl Environment {
 
     pub fn get_at(&self, distance: usize, name: &Token) -> Result<Object, Error> {
         let key = &*name.lexeme;
-        Ok(self
-            .ancestor(distance)
-            .borrow()
-            .values
-            .get(key)
-            .expect(&format!("Undefined variable '{}'", key))
-            .clone())
+        if distance > 0 {
+            Ok(self
+                .ancestor(distance)
+                .borrow()
+                .values
+                .get(key)
+                .expect(&format!("Undefined variable '{}'", key))
+                .clone())
+        } else {
+            Ok(self
+                .values
+                .get(key)
+                .expect(&format!("Undefined variable '{}'", key))
+                .clone())
+        }
     }
 
     pub fn assign_at(&mut self, distance: usize, name: &Token, value: Object) -> Result<(), Error> {
-        self.ancestor(distance)
-            .borrow_mut()
-            .values
-            .insert(name.lexeme.clone(), value);
+        if distance > 0 {
+            self.ancestor(distance)
+                .borrow_mut()
+                .values
+                .insert(name.lexeme.clone(), value);
+        } else {
+            self.values.insert(name.lexeme.clone(), value);
+        }
         Ok(())
     }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -31,6 +31,10 @@ impl Environment {
         self.values.insert(name, value);
     }
 
+    pub fn get_at(&self, distance: usize, name: &Token) -> Result<Object, Error> {
+        unimplemented!()
+    }
+
     pub fn get(&self, name: &Token) -> Result<Object, Error> {
         let key = &*name.lexeme;
         if let Some(value) = self.values.get(key) {

--- a/src/function.rs
+++ b/src/function.rs
@@ -34,9 +34,13 @@ impl Function {
     ) -> Result<Object, Error> {
         match self {
             Function::Native { body, .. } => Ok(body(arguments)),
-            Function::User { params, body, closure, .. } => {
-                let mut environment =
-                    Rc::new(RefCell::new(Environment::from(closure)));
+            Function::User {
+                params,
+                body,
+                closure,
+                ..
+            } => {
+                let mut environment = Rc::new(RefCell::new(Environment::from(closure)));
                 for (param, argument) in params.iter().zip(arguments.iter()) {
                     environment
                         .borrow_mut()

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -274,7 +274,14 @@ impl expr::Visitor<Object> for Interpreter {
 
     fn visit_assign_expr(&mut self, name: &Token, value: &Expr) -> Result<Object, Error> {
         let v = self.evaluate(value)?;
-        self.environment.borrow_mut().assign(name, v.clone())?;
+
+        if let Some(distance) = self.locals.get(name) {
+            self.environment
+                .borrow_mut()
+                .assign_at(*distance, name, v.clone())?;
+        } else {
+            self.environment.borrow_mut().assign(name, v.clone())?;
+        }
         Ok(v)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod function;
 mod interpreter;
 mod object;
 mod parser;
+mod resolver;
 mod scanner;
 mod syntax;
 mod token;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use std::process::exit;
 use error::Error;
 use interpreter::Interpreter;
 use parser::Parser;
+use resolver::Resolver;
 use scanner::Scanner;
 use syntax::AstPrinter;
 
@@ -50,6 +51,10 @@ impl Lox {
 
         let mut parser = Parser::new(tokens);
         let statements = parser.parse()?;
+
+        let mut resolver = Resolver::new(&mut self.interpreter);
+        resolver.resolve_stmts(&statements);
+
         self.interpreter.interpret(&statements)?;
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,8 @@ impl Lox {
         let mut resolver = Resolver::new(&mut self.interpreter);
         resolver.resolve_stmts(&statements);
 
+        // TODO: check if there was an error and return.
+
         self.interpreter.interpret(&statements)?;
         Ok(())
     }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,0 +1,154 @@
+use crate::error::Error;
+use crate::interpreter::Interpreter;
+use crate::syntax::{Expr, LiteralValue, Stmt};
+use crate::syntax::{expr, stmt};
+use crate::token::Token;
+
+use std::collections::HashMap;
+
+struct Resolver {
+    interpreter: Interpreter,
+    scopes: Vec<HashMap<String, bool>>,
+}
+
+impl Resolver {
+    fn new(interpreter: Interpreter) -> Self {
+        Resolver {
+            interpreter: interpreter,
+            scopes: Vec::new(),
+        }
+    }
+
+    fn resolve_stmt(&mut self, statement: &Stmt) {
+        statement.accept(self);
+    }
+
+    fn resolve_stmts(&mut self, statements: &Vec<Stmt>) {
+        for statement in statements {
+            self.resolve_stmt(statement);
+        }
+    }
+
+    fn resolve_expr(&mut self, expression: &Expr) {
+        expression.accept(self);
+    }
+
+    fn begin_scope(&mut self) {
+        self.scopes.push(HashMap::new());
+    }
+
+    fn end_scope(&mut self) {
+        self.scopes.pop();
+    }
+
+    fn declare(&mut self, name: &Token) {
+        unimplemented!()
+    }
+
+    fn define(&mut self, name: &Token) {
+        unimplemented!()
+    }
+}
+
+impl expr::Visitor<()> for Resolver {
+
+    fn visit_assign_expr(&mut self, name: &Token, value: &Expr) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn visit_binary_expr(
+        &mut self,
+        left: &Expr,
+        operator: &Token,
+        right: &Expr,
+    ) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn visit_call_expr(
+        &mut self,
+        callee: &Expr,
+        paren: &Token,
+        arguments: &Vec<Expr>,
+    ) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn visit_grouping_expr(&mut self, expression: &Expr) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn visit_literal_expr(&self, value: &LiteralValue) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn visit_logical_expr(
+        &mut self,
+        left: &Expr,
+        operator: &Token,
+        right: &Expr,
+    ) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn visit_unary_expr(&mut self, operator: &Token, right: &Expr) -> Result<(), Error> {
+       unimplemented!()
+    }
+
+    fn visit_variable_expr(&mut self, name: &Token) -> Result<(), Error> {
+        unimplemented!()
+    }
+}
+
+impl stmt::Visitor<()> for Resolver {
+
+    fn visit_block_stmt(&mut self, statements: &Vec<Stmt>) -> Result<(), Error> {
+        self.begin_scope();
+        self.resolve_stmts(statements);
+        self.end_scope();
+        Ok(())
+    }
+
+    fn visit_expression_stmt(&mut self, expression: &Expr) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn visit_function_stmt(
+        &mut self,
+        name: &Token,
+        params: &Vec<Token>,
+        body: &Vec<Stmt>,
+    ) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn visit_if_stmt(
+        &mut self,
+        condition: &Expr,
+        else_branch: &Option<Stmt>,
+        then_branch: &Stmt,
+    ) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn visit_print_stmt(&mut self, expression: &Expr) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn visit_return_stmt(&mut self, keyword: &Token, value: &Option<Expr>) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn visit_var_stmt(&mut self, name: &Token, initializer: &Option<Expr>) -> Result<(), Error> {
+        self.declare(name);
+        if let Some(init) = initializer {
+            self.resolve_expr(init);
+        }
+        self.define(name);
+        Ok(())
+    }
+
+    fn visit_while_stmt(&mut self, condition: &Expr, body: &Stmt) -> Result<(), Error> {
+        unimplemented!()
+    }
+}

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -69,7 +69,7 @@ impl Resolver {
         self.end_scope();
     }
 
-    fn resolve_local(&self, name: &Token) {
+    fn resolve_local(&mut self, name: &Token) {
         for (i, scope) in self.scopes.iter().rev().enumerate() {
             if scope.contains_key(&name.lexeme) {
                 self.interpreter.resolve(name, i);

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -6,13 +6,13 @@ use crate::token::Token;
 
 use std::collections::HashMap;
 
-struct Resolver {
-    interpreter: Interpreter,
+pub struct Resolver<'i> {
+    interpreter: &'i mut Interpreter,
     scopes: Vec<HashMap<String, bool>>,
 }
 
-impl Resolver {
-    fn new(interpreter: Interpreter) -> Self {
+impl<'i> Resolver<'i> {
+    pub fn new(interpreter: &'i mut Interpreter) -> Self {
         Resolver {
             interpreter: interpreter,
             scopes: Vec::new(),
@@ -23,7 +23,7 @@ impl Resolver {
         statement.accept(self);
     }
 
-    fn resolve_stmts(&mut self, statements: &Vec<Stmt>) {
+    pub fn resolve_stmts(&mut self, statements: &Vec<Stmt>) {
         for statement in statements {
             self.resolve_stmt(statement);
         }
@@ -45,7 +45,7 @@ impl Resolver {
         match self.scopes.last_mut() {
             Some(ref mut scope) => {
                 scope.insert(name.lexeme.clone(), false);
-            },
+            }
             None => (),
         };
     }
@@ -54,7 +54,7 @@ impl Resolver {
         match self.scopes.last_mut() {
             Some(ref mut scope) => {
                 scope.insert(name.lexeme.clone(), true);
-            },
+            }
             None => (),
         };
     }
@@ -78,7 +78,7 @@ impl Resolver {
     }
 }
 
-impl expr::Visitor<()> for Resolver {
+impl<'i> expr::Visitor<()> for Resolver<'i> {
     fn visit_assign_expr(&mut self, name: &Token, value: &Expr) -> Result<(), Error> {
         self.resolve_expr(value);
         self.resolve_local(name);
@@ -147,7 +147,7 @@ impl expr::Visitor<()> for Resolver {
     }
 }
 
-impl stmt::Visitor<()> for Resolver {
+impl<'i> stmt::Visitor<()> for Resolver<'i> {
     fn visit_block_stmt(&mut self, statements: &Vec<Stmt>) -> Result<(), Error> {
         self.begin_scope();
         self.resolve_stmts(statements);

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::hash::{Hash, Hasher};
 extern crate phf;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -82,3 +83,12 @@ impl fmt::Display for Token {
         }
     }
 }
+
+impl Hash for Token {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.lexeme.hash(state);
+        self.line.hash(state);
+    }
+}
+
+impl Eq for Token {}


### PR DESCRIPTION
This implements [chapter 11](http://craftinginterpreters.com/resolving-and-binding.html) to resolve variables.

The resolver is probably a little odd for Rust and has two sources for bugs. For one the hash
map of the scopes uses the token instead of the expression for locals. If two tokens are on the
the same line this might be an issue. For another the `had_error` is still not implemented.