### PR TITLE
Chapter 16: Scanning on Demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ Each commit corresponds to one chapter in the book:
   
   ## Part III: A Bytecode Virtual Machine 
   * [Chapter 14: Chunks of Bytecode](https://github.com/jeschkies/lox-rs/commit/bcec748d59b568c3b6ce93d6d07b40b14f44caa0)
+  * [Chapter 15: A Virtual Machone](https://github.com/jeschkies/lox-rs/commit/5c528b63f0ea4a5cfce3757b6c0a5323cba1abf6)

--- a/bytecode/src/compiler.rs
+++ b/bytecode/src/compiler.rs
@@ -1,9 +1,24 @@
-use crate::scanner::Scanner;
+use crate::scanner::{Scanner, Token, TokenType};
 
 pub struct Compiler;
 
 impl Compiler {
     pub fn compile(&self, source: &str) {
-        Scanner::new(source);
+        let mut scanner = Scanner::new(source);
+        let mut line: i32 = -1;
+        loop {
+            let token = scanner.scan_token();
+            if token.line != line {
+                print!("{:>4}", token.line);
+                line = token.line;
+            } else {
+                print!("   | ");
+            }
+            print!("{:>2} '{}'", token.typ, token.src);
+
+            if token.typ == TokenType::EOF {
+                break;
+            }
+        }
     }
 }

--- a/bytecode/src/compiler.rs
+++ b/bytecode/src/compiler.rs
@@ -1,0 +1,9 @@
+use crate::scanner::Scanner;
+
+pub struct Compiler;
+
+impl Compiler {
+    pub fn compile(&self, source: &str) {
+        Scanner::new(source);
+    }
+}

--- a/bytecode/src/error.rs
+++ b/bytecode/src/error.rs
@@ -1,0 +1,28 @@
+use std::convert;
+use std::fmt;
+use std::io;
+
+#[derive(Debug)]
+pub enum Error {
+    Io(io::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Io(underlying) => write!(f, "IoError {}", underlying),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn description(&self) -> &str {
+        "Lox Error"
+    }
+}
+
+impl convert::From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Error::Io(e)
+    }
+}

--- a/bytecode/src/main.rs
+++ b/bytecode/src/main.rs
@@ -45,8 +45,7 @@ impl Lox {
     }
 
     fn run_file(&mut self, path: &str) -> Result<(), Error> {
-        // TODO: We might want handle the error kind and do a proper exit.
-        let source = fs::read_to_string(path)?; //.push_str("\0");
+        let source = format!("{}\0", fs::read_to_string(path)?);
 
         match self.vm.interpret(&source) {
             InterpretResult::CompileError => exit(65),

--- a/bytecode/src/main.rs
+++ b/bytecode/src/main.rs
@@ -1,35 +1,76 @@
 mod chunk;
+mod compiler;
 mod debug;
+mod error;
 mod memory;
+mod scanner;
 mod value;
 mod vm;
 
+use std::fs;
+use std::io::{self, Read};
+use std::process::exit;
+
 use chunk::{Chunk, OpCode};
 use debug::disassemble_chunk;
-use vm::VM;
+use error::Error;
+use vm::{InterpretResult, VM};
+
+struct Lox {
+    vm: VM,
+}
+
+impl Lox {
+    fn new() -> Self {
+        Lox { vm: VM::new() }
+    }
+
+    fn repl(&mut self) -> Result<(), Error> {
+        let mut line = String::new();
+        let stdin = io::stdin();
+        let mut handle = stdin.lock();
+
+        loop {
+            print!("> ");
+
+            if handle.read_to_string(&mut line)? == 0 {
+                println!();
+                break;
+            }
+
+            self.vm.interpret(&line);
+        }
+
+        Ok(())
+    }
+
+    fn run_file(&mut self, path: &str) -> Result<(), Error> {
+        // TODO: We might want handle the error kind and do a proper exit.
+        let source = fs::read_to_string(path)?; //.push_str("\0");
+
+        match self.vm.interpret(&source) {
+            InterpretResult::CompileError => exit(65),
+            InterpretResult::RuntimeError => exit(70),
+            InterpretResult::Ok => Ok(()),
+        }
+    }
+}
 
 fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     let mut chunk = Chunk::new();
-    let constant = chunk.add_constant(1.2);
-    chunk.write_chunk(OpCode::OpConstant(constant), 123);
 
-    let constant_2 = chunk.add_constant(3.4);
-    chunk.write_chunk(OpCode::OpConstant(constant_2), 123);
+    let mut program = Lox::new();
 
-    chunk.write_chunk(OpCode::OpAdd, 123);
-
-    let constant_3 = chunk.add_constant(5.6);
-    chunk.write_chunk(OpCode::OpConstant(constant_3), 123);
-
-    chunk.write_chunk(OpCode::OpDivide, 123);
-    chunk.write_chunk(OpCode::OpNegate, 123);
-
-    chunk.write_chunk(OpCode::OpReturn, 123);
-
-    let mut vm = VM::new(&chunk);
-
-    disassemble_chunk(&chunk, "test chunk");
-    vm.interpret();
+    let args: Vec<String> = std::env::args().collect();
+    match args.as_slice() {
+        [_, file] => program.run_file(file)?,
+        [_] => program.repl()?,
+        _ => {
+            eprintln!("Usage: lox-rs [script]");
+            exit(64)
+        }
+    }
+    //disassemble_chunk(&chunk, "test chunk");
 
     // No need to free chunk since we implemented `Drop`.
     Ok(())

--- a/bytecode/src/scanner.rs
+++ b/bytecode/src/scanner.rs
@@ -108,6 +108,20 @@ impl<'a> Scanner<'a> {
         self.char_at(self.current - 1)
     }
 
+    /// Returns the current char without consuming it.
+    fn peek(&self) -> char {
+        self.char()
+    }
+
+    /// Return the char after the current or the null character.
+    fn peek_next(&self) -> char {
+        if self.is_at_end() {
+            '\0'
+        } else {
+            self.char_at(self.current + 1)
+        }
+    }
+
     fn matches(&mut self, expected: char) -> bool {
         if self.is_at_end() {
             return false;
@@ -136,7 +150,35 @@ impl<'a> Scanner<'a> {
         }
     }
 
+    fn skip_whitespace(&mut self) {
+        loop {
+            let c: char = self.peek();
+            match c {
+                ' ' | '\r' | '\t' => {
+                    self.advance();
+                }
+                '\n' => {
+                    self.line += 1;
+                    self.advance();
+                }
+                '/' => {
+                    if self.peek_next() == '/' {
+                        // A comment goes until the end of the line.
+                        while self.peek() != '\n' && !self.is_at_end() {
+                            self.advance();
+                        }
+                    } else {
+                        return;
+                    }
+                }
+                _ => return,
+            }
+        }
+    }
+
     pub fn scan_token(&mut self) -> Token {
+        self.skip_whitespace();
+
         self.start = self.current;
 
         if self.is_at_end() {

--- a/bytecode/src/scanner.rs
+++ b/bytecode/src/scanner.rs
@@ -93,6 +93,11 @@ impl<'a> Scanner<'a> {
             .unwrap_or_else(|| panic!("expected char at offset {}", i))
     }
 
+    /// Returns the current char.
+    fn char(&self) -> char {
+        self.char_at(self.current)
+    }
+
     fn is_at_end(&self) -> bool {
         self.char_at(self.current) == '\0'
     }
@@ -101,6 +106,18 @@ impl<'a> Scanner<'a> {
         self.current += 1;
 
         self.char_at(self.current - 1)
+    }
+
+    fn matches(&mut self, expected: char) -> bool {
+        if self.is_at_end() {
+            return false;
+        }
+        if self.char() != expected {
+            return false;
+        }
+
+        self.current += 1;
+        true
     }
 
     fn make_token(&self, typ: TokenType) -> Token {
@@ -140,6 +157,38 @@ impl<'a> Scanner<'a> {
             '+' => return self.make_token(TokenType::Plus),
             '/' => return self.make_token(TokenType::Slash),
             '*' => return self.make_token(TokenType::Star),
+            '!' => {
+                let typ = if self.matches('=') {
+                    TokenType::BangEqual
+                } else {
+                    TokenType::Bang
+                };
+                return self.make_token(typ);
+            }
+            '=' => {
+                let typ = if self.matches('=') {
+                    TokenType::EqualEqual
+                } else {
+                    TokenType::Equal
+                };
+                return self.make_token(typ);
+            }
+            '<' => {
+                let typ = if self.matches('=') {
+                    TokenType::LessEqual
+                } else {
+                    TokenType::Less
+                };
+                return self.make_token(typ);
+            }
+            '>' => {
+                let typ = if self.matches('=') {
+                    TokenType::GreaterEqual
+                } else {
+                    TokenType::Greater
+                };
+                return self.make_token(typ);
+            }
             _ => unimplemented!(),
         }
 

--- a/bytecode/src/scanner.rs
+++ b/bytecode/src/scanner.rs
@@ -1,12 +1,5 @@
 use std::fmt;
 
-pub struct Scanner<'a> {
-    source: &'a str,
-    start: usize,
-    current: usize,
-    line: i32,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum TokenType {
     // Single-character tokens.
@@ -72,6 +65,13 @@ pub struct Token<'b> {
     pub line: i32,
 }
 
+pub struct Scanner<'a> {
+    source: &'a str,
+    start: usize,
+    current: usize,
+    line: i32,
+}
+
 impl<'a> Scanner<'a> {
     pub fn new(source: &'a str) -> Self {
         Scanner {
@@ -82,16 +82,25 @@ impl<'a> Scanner<'a> {
         }
     }
 
+    /// Return the character at the given position.
+    ///
+    /// This panics if the given position does not point to a valid char.
+    /// This method is copied from the [Rust Regex parse](https://github.com/rust-lang/regex/blob/master/regex-syntax/src/ast/parse.rs#L461).
+    fn char_at(&self, i: usize) -> char {
+        self.source[i..]
+            .chars()
+            .next()
+            .unwrap_or_else(|| panic!("expected char at offset {}", i))
+    }
+
     fn is_at_end(&self) -> bool {
-        // TODO: `nth` is O(n). We should be faster.
-        self.source.chars().nth(self.current).unwrap() == '\0'
+        self.char_at(self.current) == '\0'
     }
 
     fn advance(&mut self) -> char {
         self.current += 1;
 
-        // TODO: `nth` is O(n). We should be faster.
-        self.source.chars().nth(self.current - 1).unwrap()
+        self.char_at(self.current - 1)
     }
 
     fn make_token(&self, typ: TokenType) -> Token {
@@ -120,17 +129,17 @@ impl<'a> Scanner<'a> {
         let c: char = self.advance();
 
         match c {
-            '('=> return self.make_token(TokenType::LeftParen),
-            ')'=> return self.make_token(TokenType::RightParen),
-            '{'=> return self.make_token(TokenType::LeftBrace),
-            '}'=> return self.make_token(TokenType::RightBrace),
-            ';'=> return self.make_token(TokenType::Semicolon),
-            ','=> return self.make_token(TokenType::Comma),
-            '.'=> return self.make_token(TokenType::Dot),
-            '-'=> return self.make_token(TokenType::Minus),
-            '+'=> return self.make_token(TokenType::Plus),
-            '/'=> return self.make_token(TokenType::Slash),
-            '*'=> return self.make_token(TokenType::Star),
+            '(' => return self.make_token(TokenType::LeftParen),
+            ')' => return self.make_token(TokenType::RightParen),
+            '{' => return self.make_token(TokenType::LeftBrace),
+            '}' => return self.make_token(TokenType::RightBrace),
+            ';' => return self.make_token(TokenType::Semicolon),
+            ',' => return self.make_token(TokenType::Comma),
+            '.' => return self.make_token(TokenType::Dot),
+            '-' => return self.make_token(TokenType::Minus),
+            '+' => return self.make_token(TokenType::Plus),
+            '/' => return self.make_token(TokenType::Slash),
+            '*' => return self.make_token(TokenType::Star),
             _ => unimplemented!(),
         }
 

--- a/bytecode/src/scanner.rs
+++ b/bytecode/src/scanner.rs
@@ -1,7 +1,115 @@
-pub struct Scanner;
+use std::fmt;
 
-impl Scanner {
-    pub fn new(source: &str) -> Self {
-        Scanner
+pub struct Scanner<'a> {
+    source: &'a str,
+    start: usize,
+    current: usize,
+    line: i32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TokenType {
+    // Single-character tokens.
+    LeftParen,
+    RightParen,
+    LeftBrace,
+    RightBrace,
+    Comma,
+    Dot,
+    Minus,
+    Plus,
+    Semicolon,
+    Slash,
+    Star,
+
+    // One or two character tokens.
+    Bang,
+    BangEqual,
+    Equal,
+    EqualEqual,
+    Greater,
+    GreaterEqual,
+    Less,
+    LessEqual,
+
+    // Literals.
+    Identifier,
+    String,
+    Number,
+
+    // Keywords.
+    And,
+    Class,
+    Else,
+    False,
+    Fun,
+    For,
+    If,
+    Nil,
+    Or,
+    Print,
+    Return,
+    Super,
+    This,
+    True,
+    Var,
+    While,
+
+    Error,
+    EOF,
+}
+
+impl fmt::Display for TokenType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // We display enums as integer values as it were a C-like enum.
+        write!(f, "{}", *self as i32)
+    }
+}
+
+pub struct Token<'b> {
+    pub typ: TokenType,
+    pub src: &'b str,
+    pub line: i32,
+}
+
+impl<'a> Scanner<'a> {
+    pub fn new(source: &'a str) -> Self {
+        Scanner {
+            source: source,
+            start: 0,
+            current: 0,
+            line: 1,
+        }
+    }
+
+    fn is_at_end(&self) -> bool {
+        // `nth` is O(n). We should be faster.
+        self.source.chars().nth(self.current).unwrap() == '\0'
+    }
+
+    fn make_token(&self, typ: TokenType) -> Token {
+        Token {
+            typ: typ,
+            src: &self.source[self.start..self.current],
+            line: self.line,
+        }
+    }
+
+    fn error_token(&self, message: &'static str) -> Token {
+        Token {
+            typ: TokenType::Error,
+            src: message,
+            line: self.line,
+        }
+    }
+
+    pub fn scan_token(&mut self) -> Token {
+        self.start = self.current;
+
+        if self.is_at_end() {
+            return self.make_token(TokenType::EOF);
+        }
+
+        return self.error_token("Unexpected character.");
     }
 }

--- a/bytecode/src/scanner.rs
+++ b/bytecode/src/scanner.rs
@@ -98,6 +98,22 @@ impl<'a> Scanner<'a> {
         self.char_at(self.current)
     }
 
+    fn is_alpha(&self, c: char) -> bool {
+        match c {
+            'a'..='z' => true,
+            'A'..='Z' => true,
+            '_' => true,
+            _ => false,
+        }
+    }
+
+    fn is_digit(&self, c: char) -> bool {
+        match c {
+            '0'..='9' => true,
+            _ => false,
+        }
+    }
+
     fn is_at_end(&self) -> bool {
         self.char_at(self.current) == '\0'
     }
@@ -176,6 +192,99 @@ impl<'a> Scanner<'a> {
         }
     }
 
+    fn check_keyword(&self, start: usize, length: usize, rest: &str, typ: TokenType) -> TokenType {
+        let left = &self.source[(self.start + start)..(self.start + start + length)];
+        if self.current - self.start == start + length && left == rest {
+            typ
+        } else {
+            TokenType::Identifier
+        }
+    }
+
+    fn identifier_type(&mut self) -> TokenType {
+        match self.char_at(self.start) {
+            'a' => self.check_keyword(1, 2, "nd", TokenType::And),
+            'c' => self.check_keyword(1, 4, "lass", TokenType::Class),
+            'e' => self.check_keyword(1, 3, "lse", TokenType::Else),
+            'f' => {
+                if self.current - self.start > 1 {
+                    match self.char_at(self.start + 1) {
+                        'a' => self.check_keyword(2, 3, "lse", TokenType::False),
+                        'o' => self.check_keyword(2, 1, "r", TokenType::For),
+                        'u' => self.check_keyword(2, 1, "n", TokenType::Fun),
+                        _ => TokenType::Identifier,
+                    }
+                } else {
+                    TokenType::Identifier
+                }
+            }
+            'i' => self.check_keyword(1, 1, "f", TokenType::If),
+            'n' => self.check_keyword(1, 2, "il", TokenType::Nil),
+            'o' => self.check_keyword(1, 1, "r", TokenType::Or),
+            'p' => self.check_keyword(1, 4, "rint", TokenType::Print),
+            'r' => self.check_keyword(1, 5, "eturn", TokenType::Return),
+            's' => self.check_keyword(1, 4, "uper", TokenType::Super),
+            't' => {
+                if self.current - self.start > 1 {
+                    match self.char_at(self.start + 1) {
+                        'h' => self.check_keyword(2, 2, "is", TokenType::This),
+                        'r' => self.check_keyword(2, 2, "ue", TokenType::True),
+                        _ => TokenType::Identifier,
+                    }
+                } else {
+                    TokenType::Identifier
+                }
+            }
+            'v' => self.check_keyword(1, 2, "ar", TokenType::Var),
+            'w' => self.check_keyword(1, 4, "hile", TokenType::While),
+            _ => TokenType::Identifier,
+        }
+    }
+
+    fn identifier(&mut self) -> Token {
+        while self.is_alpha(self.peek()) || self.is_digit(self.peek()) {
+            self.advance();
+        }
+
+        let typ = self.identifier_type();
+        self.make_token(typ)
+    }
+
+    fn number(&mut self) -> Token {
+        while self.is_digit(self.peek()) {
+            self.advance();
+        }
+
+        // Look for a fractional part.
+        if self.peek() == '.' && self.is_digit(self.peek_next()) {
+            // Consume the "."
+            self.advance();
+
+            while self.is_digit(self.peek()) {
+                self.advance();
+            }
+        }
+
+        self.make_token(TokenType::Number)
+    }
+
+    fn string(&mut self) -> Token {
+        while self.peek() != '=' && !self.is_at_end() {
+            if self.peek() != '\n' {
+                self.line += 1;
+            }
+            self.advance();
+        }
+
+        if self.is_at_end() {
+            return self.error_token("Unterminated string.");
+        }
+
+        // The closing quote.
+        self.advance();
+        self.make_token(TokenType::String)
+    }
+
     pub fn scan_token(&mut self) -> Token {
         self.skip_whitespace();
 
@@ -186,6 +295,13 @@ impl<'a> Scanner<'a> {
         }
 
         let c: char = self.advance();
+
+        if self.is_alpha(c) {
+            return self.identifier();
+        }
+        if self.is_digit(c) {
+            return self.number();
+        }
 
         match c {
             '(' => return self.make_token(TokenType::LeftParen),
@@ -231,9 +347,39 @@ impl<'a> Scanner<'a> {
                 };
                 return self.make_token(typ);
             }
+            '=' => return self.string(),
             _ => unimplemented!(),
         }
 
         return self.error_token("Unexpected character.");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scan_token_type() {
+        let mut scanner = Scanner::new(
+            "and class else false\r fun \nfor if nil or print return super this true var while\0",
+        );
+
+        assert_eq!(scanner.scan_token().typ, TokenType::And);
+        assert_eq!(scanner.scan_token().typ, TokenType::Class);
+        assert_eq!(scanner.scan_token().typ, TokenType::Else);
+        assert_eq!(scanner.scan_token().typ, TokenType::False);
+        assert_eq!(scanner.scan_token().typ, TokenType::Fun);
+        assert_eq!(scanner.scan_token().typ, TokenType::For);
+        assert_eq!(scanner.scan_token().typ, TokenType::If);
+        assert_eq!(scanner.scan_token().typ, TokenType::Nil);
+        assert_eq!(scanner.scan_token().typ, TokenType::Or);
+        assert_eq!(scanner.scan_token().typ, TokenType::Print);
+        assert_eq!(scanner.scan_token().typ, TokenType::Return);
+        assert_eq!(scanner.scan_token().typ, TokenType::Super);
+        assert_eq!(scanner.scan_token().typ, TokenType::This);
+        assert_eq!(scanner.scan_token().typ, TokenType::True);
+        assert_eq!(scanner.scan_token().typ, TokenType::Var);
+        assert_eq!(scanner.scan_token().typ, TokenType::While);
     }
 }

--- a/bytecode/src/scanner.rs
+++ b/bytecode/src/scanner.rs
@@ -1,0 +1,7 @@
+pub struct Scanner;
+
+impl Scanner {
+    pub fn new(source: &str) -> Self {
+        Scanner
+    }
+}

--- a/bytecode/src/scanner.rs
+++ b/bytecode/src/scanner.rs
@@ -83,8 +83,15 @@ impl<'a> Scanner<'a> {
     }
 
     fn is_at_end(&self) -> bool {
-        // `nth` is O(n). We should be faster.
+        // TODO: `nth` is O(n). We should be faster.
         self.source.chars().nth(self.current).unwrap() == '\0'
+    }
+
+    fn advance(&mut self) -> char {
+        self.current += 1;
+
+        // TODO: `nth` is O(n). We should be faster.
+        self.source.chars().nth(self.current - 1).unwrap()
     }
 
     fn make_token(&self, typ: TokenType) -> Token {
@@ -108,6 +115,23 @@ impl<'a> Scanner<'a> {
 
         if self.is_at_end() {
             return self.make_token(TokenType::EOF);
+        }
+
+        let c: char = self.advance();
+
+        match c {
+            '('=> return self.make_token(TokenType::LeftParen),
+            ')'=> return self.make_token(TokenType::RightParen),
+            '{'=> return self.make_token(TokenType::LeftBrace),
+            '}'=> return self.make_token(TokenType::RightBrace),
+            ';'=> return self.make_token(TokenType::Semicolon),
+            ','=> return self.make_token(TokenType::Comma),
+            '.'=> return self.make_token(TokenType::Dot),
+            '-'=> return self.make_token(TokenType::Minus),
+            '+'=> return self.make_token(TokenType::Plus),
+            '/'=> return self.make_token(TokenType::Slash),
+            '*'=> return self.make_token(TokenType::Star),
+            _ => unimplemented!(),
         }
 
         return self.error_token("Unexpected character.");

--- a/bytecode/src/vm.rs
+++ b/bytecode/src/vm.rs
@@ -1,4 +1,5 @@
 use crate::chunk::{Chunk, OpCode};
+use crate::compiler::Compiler;
 use crate::debug::disassemble_instruction;
 use crate::value::{print_value, Value};
 
@@ -14,8 +15,8 @@ macro_rules! binary_op{
 
 static STACK_MAX: usize = 245;
 
-pub struct VM<'a> {
-    chunk: &'a Chunk,
+pub struct VM {
+    chunk: Chunk, // TODO: might use ref again
     ip: *const OpCode,
     stack: Vec<Value>,
 }
@@ -27,17 +28,21 @@ pub enum InterpretResult {
     RuntimeError,
 }
 
-impl<'a> VM<'a> {
-    pub fn new(chunk: &'a Chunk) -> Self {
+impl VM {
+    pub fn new() -> Self {
+        let chunk = Chunk::new();
+        let ip = chunk.code;
         VM {
             chunk: chunk,
-            ip: chunk.code,
+            ip: ip,
             stack: Vec::with_capacity(STACK_MAX),
         }
     }
 
-    pub fn interpret(mut self) -> InterpretResult {
-        self.run()
+    pub fn interpret(&mut self, source: &str) -> InterpretResult {
+        let compiler = Compiler;
+        compiler.compile(source);
+        InterpretResult::Ok
     }
 
     fn run(mut self) -> InterpretResult {
@@ -55,7 +60,7 @@ impl<'a> VM<'a> {
                     print!("[{:?}]", slot);
                 }
                 println!();
-                disassemble_instruction(self.chunk, &instruction, position);
+                disassemble_instruction(&self.chunk, &instruction, position);
                 position += 1;
             }
 


### PR DESCRIPTION
This implements [chapter 16](http://craftinginterpreters.com/scanning-on-demand.html).

We are not handling all errors and let them propagate up. The only difference to clox is the
character access. We don't use pointers but indices.